### PR TITLE
feat!: long-only todoke-prefixed CLI options (v1.0.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "todoke"
-version = "0.3.19"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "todoke"
-version = "0.3.19"
+version = "1.0.0"
 edition = "2024"
 rust-version = "1.85"
 description = "A rule-driven file and URL dispatcher: hands incoming paths (or URLs) to the right handler based on TOML-defined rules."

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ match = '^issue:(\d+)$'
 to = "gh-issue"
 
 # Git refs — branch names, tags, short SHAs, etc. `input_type = "raw"`
-# pins this rule to `--as raw` so that bare words like `HEAD` / `main`,
+# pins this rule to `--todoke-as raw` so that bare words like `HEAD` / `main`,
 # which auto-detect as File, don't accidentally trigger the GitHub URL
 # handler when you meant to open a local file by that name.
 [[rules]]
@@ -167,15 +167,15 @@ todoke issue:42      # → firefox opens issues/42
 
 # Bare words like `HEAD` or `Makefile` auto-detect as File (so
 # `$EDITOR=todoke Makefile` Just Works — see the $EDITOR section below).
-# When you want `HEAD` routed as a git ref instead, pass `--as raw` and
-# wire the matching rule with `input_type = "raw"`:
-todoke --as raw HEAD # → firefox opens the repo tree at HEAD
+# When you want `HEAD` routed as a git ref instead, pass `--todoke-as raw`
+# and wire the matching rule with `input_type = "raw"`:
+todoke --todoke-as raw HEAD # → firefox opens the repo tree at HEAD
 
 # See which rule would match, without actually dispatching
 todoke check notes.md https://example.com issue:42
 
 # Same dispatch logic, don't execute
-todoke --dry-run notes.md
+todoke --todoke-dry-run notes.md
 
 # Lint the config for common footguns
 todoke doctor
@@ -404,7 +404,7 @@ A delivery target (the value behind a rule's `to = "<name>"`).
 | `group`   | string                    | `"default"`  | instance identity (one nvim per group)       |
 | `mode`    | string                    | `"remote"`   | free-form; `"remote"` / `"new"` are reserved for neovim behavior, otherwise used only to pick `args.<mode>` |
 | `sync`    | bool                      | `false`      | `true` = block until handler exits           |
-| `input_type` | `"file" \| "url" \| "raw"` or array | all kinds | restrict which input kinds this rule applies to. Example: `input_type = "raw"` makes the rule fire only for `--as raw` / auto-detected Raw inputs — useful for git-ref style patterns (`^HEAD$`, `^main$`) that must not shadow a local file of the same name. |
+| `input_type` | `"file" \| "url" \| "raw"` or array | all kinds | restrict which input kinds this rule applies to. Example: `input_type = "raw"` makes the rule fire only for `--todoke-as raw` / auto-detected Raw inputs — useful for git-ref style patterns (`^HEAD$`, `^main$`) that must not shadow a local file of the same name. |
 | `joined`   | bool                       | `false`     | match against the full argv-join (all positional args concatenated with spaces, **pre auto-detect**) instead of each input individually. On a hit, the named capture `input` is re-classified via `Input::from_arg` and becomes the batch's sole input; other captures ride along in `{{ cap.<name> }}` for the target's args templates. Designed for `$EDITOR=todoke +42 file.txt` style calls. Mutually exclusive with `passthrough`. |
 | `passthrough` | bool                    | `false`     | match against the **raw argv** (pre auto-detect) per input. On a hit, the raw string is forwarded to the target's start-up argv instead of being opened/edited. Use for editor flags like `+42` / `-c :set ft=...`. Mutually exclusive with `joined`. |
 | `consumes` | non-negative int           | `0`         | only valid with `passthrough = true`. When the rule matches, also forward the next **N** argv items as part of the same passthrough sequence. Designed for spaced-value flags like `-c :set ft=md` where the value is its own argv — a `consumes = 1` on `match = '^-c$'` keeps the flag and its value together. |
@@ -470,13 +470,19 @@ todoke kill <group> | --all    # terminate instances
 todoke config path | edit | validate | show
 ```
 
-Flags:
+Flags (all long-only and `--todoke-` prefixed so they don't collide with
+flags the downstream tool expects):
 
-- `-c, --config <PATH>` — override config path
-- `-E, --editor <NAME>` — bypass rule, force handler
-- `-G, --group <NAME>`  — bypass rule, force group
-- `--dry-run`           — print the resolved plan without executing
-- `-v, --verbose`       — `-v` = info, `-vv` = debug, `-vvv` = trace
+- `--todoke-config <PATH>` — override config path
+- `--todoke-editor <NAME>` — bypass rule, force handler
+- `--todoke-group <NAME>`  — bypass rule, force group
+- `--todoke-as <KIND>`     — force input classification (`file` / `url` / `raw`)
+- `--todoke-dry-run`       — print the resolved plan without executing
+- `--todoke-verbose`       — repeat for more verbosity (info / debug / trace)
+
+Positional args are collected with `trailing_var_arg + allow_hyphen_values`,
+so `-c :set ft=md` / `+42` / `-abc` flow straight through to whichever
+passthrough / normal rule matches — no `--` separator needed.
 
 Logging is also controllable via `RUST_LOG`.
 

--- a/README.md
+++ b/README.md
@@ -480,12 +480,18 @@ flags the downstream tool expects):
 - `--todoke-dry-run`       — print the resolved plan without executing
 - `--todoke-verbose`       — repeat for more verbosity (info / debug / trace)
 
-Positional args are collected with `allow_hyphen_values = true`, so
-`-c :set ft=md` / `+42` / `-abc` flow straight through to whichever
-passthrough / normal rule matches without needing a `--` separator.
-(clap still consumes the `--` end-of-options marker itself, so if a
+Positional args are collected with `trailing_var_arg = true` +
+`allow_hyphen_values = true`, so `-c :set ft=md` / `+42` / `-abc` flow
+straight through to whichever passthrough / normal rule matches — no
+`--` separator required. Trade-off: **todoke's own flags must precede
+the inputs** (e.g. `todoke --todoke-dry-run +42 foo.txt`); flags
+written after the first input get absorbed as positional. That's the
+right shape for `$EDITOR` callers, who never inject todoke flags
+after inputs.
+
+clap still consumes the `--` end-of-options marker itself, so if a
 downstream tool *requires* a literal `--` in its argv, pass it some
-other way — e.g. a `consumes_rest` rule keyed on a non-`--` sentinel.)
+other way — e.g. a `consumes_rest` rule keyed on a non-`--` sentinel.
 
 Logging is also controllable via `RUST_LOG`.
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ to = "code"
 mode = "remote"
 
 # Raw strings — custom-scheme bare ids like `issue:42` auto-detect as Raw
-# so this rule fires without `--as`. Capture groups are available to the
+# so this rule fires without `--todoke-as`. Capture groups are available to the
 # handler as `{{ cap.1 }}` / `{{ cap.name }}`.
 [[rules]]
 name = "gh-issue"
@@ -161,7 +161,7 @@ todoke https://github.com/yukimemi/todoke  # → gh rule → firefox
 todoke https://example.com                  # → url-default rule → firefox
 
 # Raw strings match rules too. `<scheme>:<body>` bare ids auto-detect as
-# Raw so gh-issue fires without `--as`. Captures are available as
+# Raw so gh-issue fires without `--todoke-as`. Captures are available as
 # `{{ cap.N }}`.
 todoke issue:42      # → firefox opens issues/42
 

--- a/README.md
+++ b/README.md
@@ -480,9 +480,12 @@ flags the downstream tool expects):
 - `--todoke-dry-run`       — print the resolved plan without executing
 - `--todoke-verbose`       — repeat for more verbosity (info / debug / trace)
 
-Positional args are collected with `trailing_var_arg + allow_hyphen_values`,
-so `-c :set ft=md` / `+42` / `-abc` flow straight through to whichever
-passthrough / normal rule matches — no `--` separator needed.
+Positional args are collected with `allow_hyphen_values = true`, so
+`-c :set ft=md` / `+42` / `-abc` flow straight through to whichever
+passthrough / normal rule matches without needing a `--` separator.
+(clap still consumes the `--` end-of-options marker itself, so if a
+downstream tool *requires* a literal `--` in its argv, pass it some
+other way — e.g. a `consumes_rest` rule keyed on a non-`--` sentinel.)
 
 Logging is also controllable via `RUST_LOG`.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,15 +15,24 @@ pub mod config;
     long_about = None,
 )]
 pub struct Cli {
-    // All positional inputs are collected without special treatment for
-    // leading `-` / `+`, so `$EDITOR=todoke`-style invocations like
-    // `todoke -c :set ft=md +42 file.txt` don't need `--` to escape the
-    // flags — they just flow through to whichever passthrough / normal
-    // rule matches. todoke's own options are long-only and `--todoke-`
-    // prefixed to avoid colliding with the flags downstream tools expect.
+    // `trailing_var_arg` is load-bearing: on some platforms (Windows CI)
+    // clap rejects unknown short flags like `-f` even with
+    // `allow_hyphen_values = true` — the flag parser fires first and the
+    // value never reaches the positional collector. `trailing_var_arg`
+    // forces everything after the first positional into this Vec, so
+    // `$EDITOR=todoke`-style invocations (`todoke -c :set ft=md +42 file.txt`)
+    // flow through to whichever passthrough / normal rule matches.
+    //
+    // Trade-off: todoke's own flags must precede inputs.
+    // `todoke --todoke-dry-run +42 file.txt` works; the reverse order
+    // `todoke +42 file.txt --todoke-dry-run` treats the trailing flag
+    // as a positional. That's the right shape for $EDITOR callers
+    // (which never inject todoke flags after inputs) and for the
+    // Quick-start idioms in the README.
     #[arg(
         value_name = "INPUTS",
         help = "Files, URLs, or raw strings to dispatch (no subcommand = default dispatch)",
+        trailing_var_arg = true,
         allow_hyphen_values = true
     )]
     pub files: Vec<PathBuf>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,7 +24,6 @@ pub struct Cli {
     #[arg(
         value_name = "INPUTS",
         help = "Files, URLs, or raw strings to dispatch (no subcommand = default dispatch)",
-        trailing_var_arg = true,
         allow_hyphen_values = true
     )]
     pub files: Vec<PathBuf>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,15 +15,22 @@ pub mod config;
     long_about = None,
 )]
 pub struct Cli {
+    // All positional inputs are collected without special treatment for
+    // leading `-` / `+`, so `$EDITOR=todoke`-style invocations like
+    // `todoke -c :set ft=md +42 file.txt` don't need `--` to escape the
+    // flags — they just flow through to whichever passthrough / normal
+    // rule matches. todoke's own options are long-only and `--todoke-`
+    // prefixed to avoid colliding with the flags downstream tools expect.
     #[arg(
         value_name = "INPUTS",
-        help = "Files, URLs, or raw strings to dispatch (no subcommand = default dispatch)"
+        help = "Files, URLs, or raw strings to dispatch (no subcommand = default dispatch)",
+        trailing_var_arg = true,
+        allow_hyphen_values = true
     )]
     pub files: Vec<PathBuf>,
 
     #[arg(
-        short = 'c',
-        long = "config",
+        long = "todoke-config",
         value_name = "PATH",
         help = "Override config path",
         global = true
@@ -31,23 +38,21 @@ pub struct Cli {
     pub config: Option<PathBuf>,
 
     #[arg(
-        short = 'E',
-        long = "editor",
+        long = "todoke-editor",
         value_name = "NAME",
         help = "Bypass rules, force handler"
     )]
     pub editor: Option<String>,
 
     #[arg(
-        short = 'G',
-        long = "group",
+        long = "todoke-group",
         value_name = "NAME",
         help = "Bypass rules, force group"
     )]
     pub group: Option<String>,
 
     #[arg(
-        long = "as",
+        long = "todoke-as",
         value_name = "KIND",
         value_enum,
         help = "Force how each argument is classified (skip auto-detection)"
@@ -55,12 +60,16 @@ pub struct Cli {
     pub as_kind: Option<InputKind>,
 
     #[arg(
-        long = "dry-run",
+        long = "todoke-dry-run",
         help = "Resolve rules and log decisions without dispatching"
     )]
     pub dry_run: bool,
 
-    #[arg(short = 'v', long = "verbose", action = clap::ArgAction::Count, help = "Increase log verbosity (-v, -vv)")]
+    #[arg(
+        long = "todoke-verbose",
+        action = clap::ArgAction::Count,
+        help = "Increase log verbosity (repeat for more: --todoke-verbose --todoke-verbose)",
+    )]
     pub verbose: u8,
 
     #[command(subcommand)]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -76,7 +76,11 @@ fn no_args_uses_default_rule() {
         "#,
     );
 
-    let (ok, out, err) = run_with(&["--config", &config.to_string_lossy(), "--dry-run"]);
+    let (ok, out, err) = run_with(&[
+        "--todoke-config",
+        &config.to_string_lossy(),
+        "--todoke-dry-run",
+    ]);
     assert!(ok, "stderr: {err}");
     assert!(out.contains("to=echo"), "stdout: {out}");
     assert!(out.contains("rule=default"), "stdout: {out}");
@@ -160,7 +164,7 @@ fn gnu_posix_argument_syntax_parses_end_to_end() {
     let cfg_str = config.to_string_lossy().into_owned();
 
     let run_dry = |extra: &[&str]| -> String {
-        let mut args: Vec<&str> = vec!["--config", &cfg_str, "--dry-run", "--"];
+        let mut args: Vec<&str> = vec!["--todoke-config", &cfg_str, "--todoke-dry-run", "--"];
         args.extend_from_slice(extra);
         let (ok, out, err) = run_with(&args);
         assert!(ok, "failed for {extra:?}: stderr: {err}");
@@ -287,7 +291,11 @@ fn no_args_no_rules_errors() {
         "#,
     );
 
-    let (ok, _out, err) = run_with(&["--config", &config.to_string_lossy(), "--dry-run"]);
+    let (ok, _out, err) = run_with(&[
+        "--todoke-config",
+        &config.to_string_lossy(),
+        "--todoke-dry-run",
+    ]);
     assert!(!ok);
     assert!(err.contains("no rule matches empty-args"), "stderr: {err}");
 }
@@ -326,9 +334,9 @@ fn dry_run_plans_default_rule() {
     );
 
     let (ok, out, err) = run_with(&[
-        "--config",
+        "--todoke-config",
         &config.to_string_lossy(),
-        "--dry-run",
+        "--todoke-dry-run",
         &file.to_string_lossy(),
     ]);
     assert!(ok, "stderr: {err}");
@@ -366,7 +374,7 @@ fn check_shows_matched_rule_per_file() {
     );
 
     let (ok, out, err) = run_with(&[
-        "--config",
+        "--todoke-config",
         &config.to_string_lossy(),
         "check",
         &rs_file.to_string_lossy(),
@@ -398,9 +406,9 @@ fn invalid_config_reports_error() {
     write_file(&config, "this is not valid toml [[[");
 
     let (ok, _out, err) = run_with(&[
-        "--config",
+        "--todoke-config",
         &config.to_string_lossy(),
-        "--dry-run",
+        "--todoke-dry-run",
         &file.to_string_lossy(),
     ]);
     assert!(!ok);
@@ -423,9 +431,9 @@ fn unknown_to_reference_reports_error() {
     );
 
     let (ok, _out, err) = run_with(&[
-        "--config",
+        "--todoke-config",
         &config.to_string_lossy(),
-        "--dry-run",
+        "--todoke-dry-run",
         &file.to_string_lossy(),
     ]);
     assert!(!ok);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -99,12 +99,15 @@ fn gnu_posix_argument_syntax_parses_end_to_end() {
     //   - short spaced `-s val`          (two argv, consumes = 1)
     //   - long spaced `--long val`       (two argv, consumes = 1)
     //   - variadic `-p a b c`            (consumes_until)
-    //   - GNU separator `-- x y`         (consumes_rest)
     //   - positional file                (file input)
     //   - stdin marker `-`               (passthrough)
     //
     // The rule set uses match regexes anchored to full argv, so every
     // pattern lands in exactly one rule.
+    //
+    // GNU separator `--` is not exercised here because clap consumes it
+    // as the end-of-options marker before todoke's argv parser sees it —
+    // `consumes_rest` is covered by a dedicated rule pattern below.
 
     let dir = temp_dir();
     let config = dir.join("todoke.toml");
@@ -138,10 +141,12 @@ fn gnu_posix_argument_syntax_parses_end_to_end() {
             passthrough = true
             consumes_until = '^[-+]'
 
-            # GNU separator: everything after `--` is for the target
+            # `++rest` sentinel: after this token, eat every remaining argv.
+            # Uses a non-`--` sentinel because clap swallows `--` before it
+            # reaches todoke's own argv parser.
             [[rules]]
-            name = "gnu-separator"
-            match = '^--$'
+            name = "rest-sentinel"
+            match = '^\+\+rest$'
             to = "echo"
             passthrough = true
             consumes_rest = true
@@ -163,8 +168,11 @@ fn gnu_posix_argument_syntax_parses_end_to_end() {
 
     let cfg_str = config.to_string_lossy().into_owned();
 
+    // No `--` separator: the whole point of `allow_hyphen_values` on the
+    // positional is that hyphen-shaped argv (`-f`, `+42`, `-sfoo`, …)
+    // flow through as positionals without escape.
     let run_dry = |extra: &[&str]| -> String {
-        let mut args: Vec<&str> = vec!["--todoke-config", &cfg_str, "--todoke-dry-run", "--"];
+        let mut args: Vec<&str> = vec!["--todoke-config", &cfg_str, "--todoke-dry-run"];
         args.extend_from_slice(extra);
         let (ok, out, err) = run_with(&args);
         assert!(ok, "failed for {extra:?}: stderr: {err}");
@@ -234,9 +242,9 @@ fn gnu_posix_argument_syntax_parses_end_to_end() {
             expect_file_contains: &[],
         },
         Case {
-            label: "GNU separator (-- x y)",
-            args: &["--", "x", "y"],
-            expect_passthrough: &["--", "x", "y"],
+            label: "rest sentinel (++rest x y)",
+            args: &["++rest", "x", "y"],
+            expect_passthrough: &["++rest", "x", "y"],
             expect_file_contains: &[],
         },
         Case {
@@ -252,9 +260,9 @@ fn gnu_posix_argument_syntax_parses_end_to_end() {
             expect_file_contains: &[],
         },
         Case {
-            label: "mixed (-s val -p a b -- z)",
-            args: &["-s", "val", "-p", "a", "b", "--", "z"],
-            expect_passthrough: &["-s", "val", "-p", "a", "b", "--", "z"],
+            label: "mixed (-s val -p a b ++rest z)",
+            args: &["-s", "val", "-p", "a", "b", "++rest", "z"],
+            expect_passthrough: &["-s", "val", "-p", "a", "b", "++rest", "z"],
             expect_file_contains: &[],
         },
     ];


### PR DESCRIPTION
## Summary

Breaking-change rework of todoke's own CLI surface so it stops colliding with the flags the downstream tool expects during \`\$EDITOR\`-style dispatch.

### What changed

| Before | After |
|---|---|
| \`-c, --config <PATH>\` | \`--todoke-config <PATH>\` |
| \`-E, --editor <NAME>\` | \`--todoke-editor <NAME>\` |
| \`-G, --group <NAME>\` | \`--todoke-group <NAME>\` |
| \`--as <KIND>\` | \`--todoke-as <KIND>\` |
| \`--dry-run\` | \`--todoke-dry-run\` |
| \`-v, --verbose\` | \`--todoke-verbose\` (repeat for more) |

The positional \`INPUTS\` collector now declares \`trailing_var_arg = true\` + \`allow_hyphen_values = true\`, so flag-shaped argv (\`-c :set ft=md\`, \`+42\`, \`-abc\`, \`--long val\`, …) flow straight through to whichever passthrough / normal rule matches — no \`--\` separator required.

### Why

todoke's intrinsic flags are rarely used in everyday dispatch (auto-detect + rules cover the common cases). The namespace collision between \`todoke -c …\` (config override) and downstream tooling like \`nvim -c :set ft=md\` was the real pain point — and \$EDITOR callers don't generally know to insert a \`--\`.

### Breaking

Scripts and shell aliases that pass the short forms or the bare long names need updating. README flag section, usage examples, and the integration test suite are all migrated in this PR.

### Version

Bump to \`1.0.0\`. Combined with the file-first auto-detect, joined / passthrough / consumes / consumes_until / consumes_rest, the input_type filter, and the documented dispatcher phase model, the public API is stable enough to drop the \`0.x\` label.

## Test plan

- [x] \`cargo test\` — 54 unit + 11 integration pass, incl. the POSIX/GNU argv-syntax table
- [x] \`cargo fmt --check\` / \`cargo clippy --all-targets -- -D warnings\`
- [ ] Confirm Gemini + CodeRabbit reviews on this PR, address feedback
- [ ] Manual \`\$EDITOR=todoke git commit\` smoke test post-merge before tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * All command-line option flags have been renamed to follow a new `--todoke-` prefix convention. Previous short flag alternatives are no longer supported.

* **New Features**
  * The CLI now accepts positional arguments that begin with hyphens or plus signs, enabling more flexible input handling.

* **Documentation**
  * README and command-line documentation updated with examples showing the new flag naming scheme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->