### PR TITLE
feat: target.gui suppresses transient cmd window on Windows (v1.1.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "todoke"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "todoke"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 rust-version = "1.85"
 description = "A rule-driven file and URL dispatcher: hands incoming paths (or URLs) to the right handler based on TOML-defined rules."

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ new    = ["--new-window"]
 
 [todoke.firefox]
 command = "firefox"
+# gui = true skips `cmd /c start` on Windows, so no cmd window flashes
+# before firefox. Unix: no-op.
+gui = true
 
 # A second firefox target specifically for issue: inputs — the URL is
 # constructed from the capture group, so append_inputs = false tells the
@@ -83,12 +86,14 @@ command = "firefox"
 # second positional.
 [todoke.gh-issue]
 command = "firefox"
+gui = true
 append_inputs = false
 args.default = ["https://github.com/yukimemi/todoke/issues/{{ cap.1 }}"]
 
 # Git-ref target: opens the GitHub tree browser at a branch / tag / sha.
 [todoke.gh-ref]
 command = "firefox"
+gui = true
 append_inputs = false
 args.default = ["https://github.com/yukimemi/todoke/tree/{{ input }}"]
 
@@ -201,6 +206,11 @@ wrapper_guis = ["neovide", "nvim-qt"]
 kind = "neovim"
 command = "{{ vars.gui }}"
 listen = '{% if is_windows() %}\\.\pipe\nvim-todoke-{{ group }}{% else %}/tmp/nvim-todoke-{{ group }}.sock{% endif %}'
+# gui = true suppresses the transient cmd window on Windows when the
+# handler is a GUI front-end (neovide / nvim-qt). Skip when using plain
+# `nvim` in a separate terminal, which needs the console that the
+# `cmd /c start` wrapper allocates.
+gui = {{ vars.gui in vars.wrapper_guis }}
 
 {% if vars.gui in vars.wrapper_guis %}
 [todoke.gui.args]
@@ -392,6 +402,7 @@ A delivery target (the value behind a rule's `to = "<name>"`).
 | `args`     | table of `<mode>` → `array<string>` | no       | args injected based on `rule.mode`; `args.default` is the fallback when no key matches |
 | `append_inputs` | bool                           | `true`   | `exec` kind only: whether each input's display string is appended as a trailing positional arg after `args`. Set to `false` when `args` already reference the input via `{{ input }}` / `{{ cap.N }}` and you don't want the raw value passed twice. |
 | `env`      | table                               | no       | env vars passed to the spawned handler                          |
+| `gui`      | bool                                | `false`  | Windows only (no-op on Unix): when `true`, detached spawns use `CREATE_NO_WINDOW + DETACHED_PROCESS` instead of `cmd /c start`, so no transient cmd window flashes before the GUI appears. Set to `true` for GUI handlers (`neovide`, `nvim-qt`, `code`, `firefox`, …) and leave `false` for terminal / TUI handlers that need a fresh console (`nvim` in a new window, `helix`, …). |
 
 ### `[[rules]]`
 

--- a/src/backends/exec.rs
+++ b/src/backends/exec.rs
@@ -30,6 +30,9 @@ pub struct ExecBackend {
     /// Whether to append each input's display string as a trailing arg
     /// after the rendered `args` list. Defaults to true.
     pub append_inputs: bool,
+    /// GUI handler hint — controls the detached-spawn code path on Windows
+    /// (skip `cmd /c start` wrapper when true so no cmd window flashes).
+    pub gui: bool,
 }
 
 pub struct DispatchCtx<'a> {
@@ -104,7 +107,7 @@ impl ExecBackend {
 
     fn run_detached(&self, cmd: &mut StdCommand) -> Result<()> {
         info!(command = %self.command, "spawning detached");
-        platform::spawn_detached(cmd, Path::new(""))
+        platform::spawn_detached(cmd, self.gui, Path::new(""))
             .with_context(|| format!("failed to spawn {}", self.command))
     }
 
@@ -139,6 +142,7 @@ mod tests {
             ],
             env: BTreeMap::new(),
             append_inputs: true,
+            gui: false,
         };
         let inputs = vec![Input::File(PathBuf::from("/tmp/hello.rs"))];
         let passthrough: Vec<String> = Vec::new();

--- a/src/backends/neovim.rs
+++ b/src/backends/neovim.rs
@@ -57,6 +57,9 @@ pub struct NeovimBackend {
     /// warns and drops them. Spawn paths (`new`, or remote fallback
     /// `spawn_detached_with_listen`) honor them.
     pub passthrough: Vec<String>,
+    /// Flagged by the caller when the `command` is a GUI front-end
+    /// (neovide, nvim-qt). Controls the detached-spawn code path on Windows.
+    pub gui: bool,
 }
 
 impl NeovimBackend {
@@ -133,6 +136,7 @@ impl NeovimBackend {
         cmd.arg("--listen").arg(&self.listen);
         platform::spawn_detached(
             &mut cmd,
+            self.gui,
             files.first().map(PathBuf::as_path).unwrap_or(Path::new("")),
         )
         .with_context(|| format!("failed to spawn {}", self.command))?;
@@ -152,6 +156,7 @@ impl NeovimBackend {
         }
         platform::spawn_detached(
             &mut cmd,
+            self.gui,
             files.first().map(PathBuf::as_path).unwrap_or(Path::new("")),
         )
         .with_context(|| format!("failed to spawn {}", self.command))?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,6 +57,17 @@ pub struct Target {
     /// don't want the raw value passed again.
     #[serde(default = "default_true")]
     pub append_inputs: bool,
+    /// Set to `true` when the handler is a **GUI** application (neovide,
+    /// nvim-qt, vscode, firefox, …). On Windows, detached spawns then use
+    /// `CREATE_NO_WINDOW + DETACHED_PROCESS` instead of the default
+    /// `cmd /c start` wrapper, so no transient cmd window flashes before
+    /// the GUI appears. On Unix this flag is a no-op.
+    ///
+    /// Leave unset / `false` for console / TUI handlers (nvim in a terminal,
+    /// helix, bat, …) — those rely on the fresh console window that
+    /// `cmd /c start` allocates.
+    #[serde(default)]
+    pub gui: bool,
 }
 
 fn default_true() -> bool {

--- a/src/config.rs
+++ b/src/config.rs
@@ -663,6 +663,23 @@ mod tests {
         assert!(!cfg.raw.rules[0].sync);
         assert!(cfg.raw.rules[0].group.is_none());
         assert_eq!(cfg.raw.todoke["a"].kind, TargetKind::Exec);
+        // gui is a new public field; lock in the backward-compatible default.
+        assert!(!cfg.raw.todoke["a"].gui);
+    }
+
+    #[test]
+    fn target_gui_parses_true() {
+        let text = r#"
+            [todoke.a]
+            command = "neovide"
+            gui = true
+
+            [[rules]]
+            match = ".*"
+            to = "a"
+        "#;
+        let cfg = load_from_str(text).unwrap();
+        assert!(cfg.raw.todoke["a"].gui);
     }
 
     #[test]

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -676,6 +676,7 @@ async fn run_neovim(
         args_remote,
         args_new,
         passthrough: batch.passthrough_inputs.clone(),
+        gui: target.gui,
     };
     backend.dispatch(&files, &batch.mode, batch.sync).await
 }
@@ -702,6 +703,7 @@ fn run_exec(
         args: rendered_args.to_vec(),
         env: target.env.clone(),
         append_inputs: target.append_inputs,
+        gui: target.gui,
     };
     let dctx = ExecCtx {
         inputs: &batch.inputs,

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -7,68 +7,105 @@ use anyhow::{Context, Result};
 
 #[cfg(windows)]
 use std::ffi::OsString;
+#[cfg(windows)]
+use std::process::Stdio;
+
+/// Windows `CreateProcess` flag: child inherits no console.
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+/// Windows `CreateProcess` flag: child gets no console at all.
+#[cfg(windows)]
+const DETACHED_PROCESS: u32 = 0x0000_0008;
 
 /// Spawn a process detached so it survives the parent's exit.
 ///
-/// # Windows
+/// When `gui` is `true`, the handler is assumed to be a GUI app (neovide,
+/// nvim-qt, VSCode, firefox, …) — on Windows we skip the `cmd /c start`
+/// wrapper and use `CREATE_NO_WINDOW + DETACHED_PROCESS` so no transient
+/// cmd window flashes before the GUI appears. stdio is set to `Stdio::null`
+/// since a GUI app doesn't need the parent terminal.
 ///
-/// We go through `cmd.exe /c start "" <program> <args>...` rather than
-/// `CreateProcess(CREATE_NEW_CONSOLE)` directly. Reason: Rust's `Command`
-/// defaults to inheriting parent stdio, which passes explicit handles in
-/// `STARTUPINFO`. Those handles take precedence over the new console the flag
-/// allocates, so a spawned TUI program (nvim, vim, helix, …) would read from
+/// When `gui` is `false` (TUI / console handlers — nvim in a terminal,
+/// helix, bat, …), we go through `cmd.exe /c start "" <program> <args>...`
+/// rather than calling `CreateProcess(CREATE_NEW_CONSOLE)` directly. Reason:
+/// Rust's `Command` defaults to inheriting parent stdio, which passes
+/// explicit handles in `STARTUPINFO`. Those handles take precedence over the
+/// new console the flag allocates, so a spawned TUI program would read from
 /// the parent shell's stdin — the new console window appears but is dead to
-/// keyboard input. `cmd.exe`'s `start` builtin goes through the Windows shell
-/// APIs that allocate the new console AND set up its stdio correctly.
+/// keyboard input. `cmd.exe`'s `start` builtin goes through the Windows
+/// shell APIs that allocate the new console AND set up its stdio correctly.
 ///
 /// # Unix
 ///
-/// Plain `spawn()` — the child inherits the calling terminal. Desktop users
-/// who want a separate window should configure a GUI editor (neovide, gvim,
-/// code, …) in their config.
-pub fn spawn_detached(cmd: &mut Command, _file_for_log: &Path) -> Result<()> {
+/// `gui` is ignored; plain `spawn()` is used and the child inherits the
+/// calling terminal. Desktop users who want a separate window should
+/// configure a GUI editor (neovide, gvim, code, …) in their config — the
+/// app itself handles window creation.
+pub fn spawn_detached(cmd: &mut Command, gui: bool, _file_for_log: &Path) -> Result<()> {
     #[cfg(windows)]
     {
-        let program = cmd.get_program().to_os_string();
-        let args: Vec<OsString> = cmd.get_args().map(|s| s.to_os_string()).collect();
-        let cwd = cmd.get_current_dir().map(|p| p.to_path_buf());
-        let envs: Vec<(OsString, Option<OsString>)> = cmd
-            .get_envs()
-            .map(|(k, v)| (k.to_os_string(), v.map(|s| s.to_os_string())))
-            .collect();
-
-        let mut wrapper = Command::new("cmd");
-        // `/c start "" program args...`
-        // The empty "" is start's window-title slot. Without it, start would
-        // consume the first quoted argument as a title when the program path
-        // contains spaces.
-        wrapper.arg("/c").arg("start").arg("");
-        wrapper.arg(&program);
-        for a in &args {
-            wrapper.arg(a);
+        if gui {
+            return spawn_detached_gui_windows(cmd);
         }
-        if let Some(d) = cwd {
-            wrapper.current_dir(d);
-        }
-        for (k, v) in envs {
-            match v {
-                Some(v) => {
-                    wrapper.env(&k, v);
-                }
-                None => {
-                    wrapper.env_remove(&k);
-                }
-            }
-        }
-        wrapper.spawn().context("spawn via cmd /c start failed")?;
-        Ok(())
+        spawn_detached_console_windows(cmd)
     }
 
     #[cfg(not(windows))]
     {
+        let _ = gui;
         cmd.spawn().context("spawn failed")?;
         Ok(())
     }
+}
+
+#[cfg(windows)]
+fn spawn_detached_gui_windows(cmd: &mut Command) -> Result<()> {
+    use std::os::windows::process::CommandExt;
+
+    cmd.creation_flags(CREATE_NO_WINDOW | DETACHED_PROCESS)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    cmd.spawn()
+        .context("spawn detached GUI (CREATE_NO_WINDOW) failed")?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn spawn_detached_console_windows(cmd: &mut Command) -> Result<()> {
+    let program = cmd.get_program().to_os_string();
+    let args: Vec<OsString> = cmd.get_args().map(|s| s.to_os_string()).collect();
+    let cwd = cmd.get_current_dir().map(|p| p.to_path_buf());
+    let envs: Vec<(OsString, Option<OsString>)> = cmd
+        .get_envs()
+        .map(|(k, v)| (k.to_os_string(), v.map(|s| s.to_os_string())))
+        .collect();
+
+    let mut wrapper = Command::new("cmd");
+    // `/c start "" program args...`
+    // The empty "" is start's window-title slot. Without it, start would
+    // consume the first quoted argument as a title when the program path
+    // contains spaces.
+    wrapper.arg("/c").arg("start").arg("");
+    wrapper.arg(&program);
+    for a in &args {
+        wrapper.arg(a);
+    }
+    if let Some(d) = cwd {
+        wrapper.current_dir(d);
+    }
+    for (k, v) in envs {
+        match v {
+            Some(v) => {
+                wrapper.env(&k, v);
+            }
+            None => {
+                wrapper.env_remove(&k);
+            }
+        }
+    }
+    wrapper.spawn().context("spawn via cmd /c start failed")?;
+    Ok(())
 }
 
 pub fn is_windows() -> bool {

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -62,6 +62,11 @@ pub fn spawn_detached(cmd: &mut Command, gui: bool, _file_for_log: &Path) -> Res
 fn spawn_detached_gui_windows(cmd: &mut Command) -> Result<()> {
     use std::os::windows::process::CommandExt;
 
+    // `creation_flags` overwrites any existing flags wholesale (std doesn't
+    // expose a getter to merge with). Callers inside this crate don't set
+    // creation flags before calling spawn_detached, so this is safe today.
+    // If a future caller needs to preserve other flags, swap this for the
+    // CreateProcessW path directly and OR them in explicitly.
     cmd.creation_flags(CREATE_NO_WINDOW | DETACHED_PROCESS)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -71,6 +76,12 @@ fn spawn_detached_gui_windows(cmd: &mut Command) -> Result<()> {
     Ok(())
 }
 
+/// TUI / console path. Unlike the GUI path above this does NOT spawn `cmd`
+/// directly; it copies its program / args / cwd / envs onto a fresh
+/// `cmd.exe /c start ""` wrapper and spawns that instead, because `start`
+/// is the only builtin that allocates a new console with correctly-wired
+/// stdio on Windows. The original `cmd` is read-only here — callers that
+/// care about `cmd` state afterwards shouldn't rely on it being mutated.
 #[cfg(windows)]
 fn spawn_detached_console_windows(cmd: &mut Command) -> Result<()> {
     let program = cmd.get_program().to_os_string();


### PR DESCRIPTION
## Summary

Adds \`gui: bool = false\` on \`[todoke.<name>]\`. When true on Windows, \`spawn_detached\` skips the \`cmd /c start\` wrapper and uses \`CREATE_NO_WINDOW | DETACHED_PROCESS\` + \`Stdio::null\` — so no transient cmd window flashes before a GUI handler (neovide / nvim-qt / VSCode / firefox / …) appears.

No-op on Unix. Default \`false\` preserves the console-window path that TUI handlers (nvim in a new terminal, helix, …) need for a properly wired fresh console.

## Why

Reported: when dispatching to neovide from todoke, a black cmd window flashes for a moment before neovide opens. Root cause is the \`cmd /c start \"\" <program>\` wrapper in \`platform.rs::spawn_detached\`. That wrapper is necessary for TUI handlers (TUI needs its own real console that \`start\` allocates with correct stdio), but it's wrong for GUI handlers that manage their own window.

Terminal output (doctor, warnings, …) is unaffected — that's parent todoke's stdout, independent of how children are spawned.

## Changes

- \`src/config.rs\`: \`Target.gui: bool = false\`
- \`src/platform.rs\`: \`spawn_detached(cmd, gui, file)\` — on Windows branches to \`CREATE_NO_WINDOW\` + \`DETACHED_PROCESS\` when gui=true, else keeps the existing \`cmd /c start\` path
- \`src/backends/{exec,neovim}.rs\`: thread \`gui\` through
- \`src/dispatcher.rs\`: pass \`target.gui\` into each backend
- README: \`[todoke.<name>]\` table row for \`gui\`, plus Quick-start firefox example flagged \`gui = true\` and the one-target-many-variants recipe uses a Tera expression \`gui = {{ vars.gui in vars.wrapper_guis }}\` so the flag flips automatically when selecting neovide / nvim-qt vs plain nvim

## Test plan

- [x] \`cargo test\` — 54 unit + 11 integration pass
- [x] \`cargo make check\` — fmt / clippy / test / locked clean
- [ ] Manual: set \`gui = true\` on a neovide target, verify no cmd flash
- [ ] Manual: keep default (false) on a nvim-in-terminal target, verify console still opens correctly
- [ ] Wait for Gemini + CodeRabbit reviews, address feedback, then merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `gui` configuration option for handlers to control Windows spawning behavior, preventing transient command windows when using GUI editors (e.g., neovide, nvim-qt). Default is `false` for terminal/TUI handlers.

* **Chores**
  * Version bump to 1.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->