### PR TITLE
feat: auto-detect template refs for append semantics (v1.2.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "todoke"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "todoke"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2024"
 rust-version = "1.85"
 description = "A rule-driven file and URL dispatcher: hands incoming paths (or URLs) to the right handler based on TOML-defined rules."

--- a/README.md
+++ b/README.md
@@ -354,6 +354,43 @@ default = ["{{ cap.pre | default(value='') | trim }}"]
 `joined` when you want a single regex describing the full invocation
 shape; use `passthrough` when each flag has its own rule.
 
+### Recipe: gvim server reuse with flag passthrough
+
+gvim has built-in `--servername` / `--remote-silent` — the vim-era
+cousin of neovim's `--listen`/msgpack-RPC. A single `kind = "exec"`
+target can re-use a gvim server per group and place passthrough flags
+**before** the `--remote-silent <file>` chunk so gvim doesn't treat
+them as extra filenames:
+
+```toml
+[todoke.gvim]
+command = "gvim"
+gui = true
+[todoke.gvim.args]
+default = [
+  "--servername", "{{ group | upper }}",
+  "{{ passthrough | join(sep=' ') }}",
+  "--remote-silent", "{{ input }}",
+]
+
+[[rules]]
+name = "vim-flag"
+match = '^[-+]'
+to = "gvim"
+passthrough = true
+
+[[rules]]
+name = "default"
+match = '.*'
+to = "gvim"
+```
+
+`{{ input }}` is referenced in `args`, so `append_inputs` auto-suppresses
+the trailing append. `{{ passthrough | join(sep=' ') }}` references
+`passthrough`, so `append_passthrough` also auto-suppresses. Result:
+`gvim --servername DEFAULT +42 --remote-silent foo.txt` — exactly what
+gvim expects, no double-paste.
+
 ### As `$EDITOR`
 
 ```sh
@@ -400,7 +437,8 @@ A delivery target (the value behind a rule's `to = "<name>"`).
 | `command`  | string                              | yes      | the handler binary (PATH-resolved)                              |
 | `listen`   | string                              | neovim   | socket / named pipe path for RPC                                |
 | `args`     | table of `<mode>` → `array<string>` | no       | args injected based on `rule.mode`; `args.default` is the fallback when no key matches |
-| `append_inputs` | bool                           | `true`   | `exec` kind only: whether each input's display string is appended as a trailing positional arg after `args`. Set to `false` when `args` already reference the input via `{{ input }}` / `{{ cap.N }}` and you don't want the raw value passed twice. |
+| `append_inputs` | bool (optional)                | **auto** | `exec` kind only. `None` / omitted = **auto**: append each input's display string to the end of argv unless any `args` template references `{{ input }}` / `{{ file_* }}` / `{{ url_* }}` (cap is intentionally ignored). `true` = force append. `false` = force skip. |
+| `append_passthrough` | bool (optional)           | **auto** | `exec` kind only. Same auto / true / false semantics as `append_inputs`, but keyed on `{{ passthrough }}` references in `args`. When you reference `{{ passthrough \| join(sep=' ') }}` to place flag-argv in a specific spot, the auto-append is suppressed so the values aren't pasted twice. |
 | `env`      | table                               | no       | env vars passed to the spawned handler                          |
 | `gui`      | bool                                | `false`  | Windows only (no-op on Unix): when `true`, detached spawns use `CREATE_NO_WINDOW + DETACHED_PROCESS` instead of `cmd /c start`, so no transient cmd window flashes before the GUI appears. Set to `true` for GUI handlers (`neovide`, `nvim-qt`, `code`, `firefox`, …) and leave `false` for terminal / TUI handlers that need a fresh console (`nvim` in a new window, `helix`, …). |
 
@@ -449,6 +487,7 @@ Available in `rule.group`, `rule.to`, `todoke.*.command`, `todoke.*.listen`,
 | `cap.0`         | full match of the `match` regex     | when a rule matched |
 | `cap.1` / `cap.2` / … | numbered capture groups       | when defined        |
 | `cap.<name>`    | named capture groups `(?P<name>…)`  | when defined        |
+| `passthrough`   | array of raw argv strings from passthrough rules in the batch (`["+42", "-c", ":set ft=md"]`). Render with `{{ passthrough \| join(sep=' ') }}`, iterate via `{% for p in passthrough %}{{ p }}{% endfor %}`. Auto-suppresses the trailing append when referenced (see `append_passthrough`). | always (empty array when no passthrough) |
 | `vars.<key>`    | your `[vars]` entries               | always        |
 | `env.<KEY>`     | process env at todoke invocation    | always        |
 

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ gui = true
 [todoke.gvim.args]
 default = [
   "--servername", "{{ group | upper }}",
-  "{{ passthrough | join(sep=' ') }}",
+  "{{ passthrough }}",                      # ← expanded inline, one argv per entry
   "--remote-silent", "{{ input }}",
 ]
 
@@ -385,11 +385,19 @@ match = '.*'
 to = "gvim"
 ```
 
-`{{ input }}` is referenced in `args`, so `append_inputs` auto-suppresses
-the trailing append. `{{ passthrough | join(sep=' ') }}` references
-`passthrough`, so `append_passthrough` also auto-suppresses. Result:
-`gvim --servername DEFAULT +42 --remote-silent foo.txt` — exactly what
-gvim expects, no double-paste.
+An args element that is *exactly* `{{ passthrough }}` (with optional
+surrounding whitespace / strip marks) is **expanded inline** — one
+argv per passthrough string. So `[-c, :set ft=md]` stays two argv,
+and an empty passthrough list contributes zero args (no literal `""`
+floating around). `{{ input }}` is also referenced, so `append_inputs`
+auto-suppresses the trailing append. Result: `gvim --servername
+DEFAULT -c :set ft=md --remote-silent foo.txt` — exactly what gvim
+expects, no double-paste, no empty-argv cruft.
+
+(If you specifically want a joined string you can still write
+`"{{ passthrough | join(sep=' ') }}"` — that path goes through the
+normal single-argv render. Use the bare `{{ passthrough }}` element
+when you want proper argv expansion, which is what gvim et al. need.)
 
 ### As `$EDITOR`
 

--- a/src/backends/exec.rs
+++ b/src/backends/exec.rs
@@ -50,6 +50,20 @@ fn references_passthrough(text: &str) -> bool {
     re.is_match(text)
 }
 
+/// True when an args array element is *exactly* `{{ passthrough }}`
+/// (with optional surrounding whitespace / strip marks, nothing else in
+/// the element). Such elements are expanded **inline** into multiple
+/// argv items — one per passthrough string — so flag + value pairs like
+/// `["-c", ":set ft=md"]` stay as two separate argv, and an empty
+/// passthrough list contributes zero args (instead of a single `""`).
+fn is_passthrough_placeholder(text: &str) -> bool {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        Regex::new(r"^\s*\{\{-?\s*passthrough\s*-?\}\}\s*$").expect("static regex")
+    });
+    re.is_match(text)
+}
+
 #[derive(Debug, Clone)]
 pub struct ExecBackend {
     pub command: String,
@@ -145,12 +159,21 @@ impl ExecBackend {
             passthrough: dctx.passthrough,
         });
         let mut tera = crate::template::new_engine();
-        self.args
-            .iter()
-            .map(|t| {
-                render(&mut tera, t, &ctx).with_context(|| format!("rendering arg template: {t}"))
-            })
-            .collect()
+        let mut out: Vec<String> = Vec::with_capacity(self.args.len());
+        for t in &self.args {
+            if is_passthrough_placeholder(t) {
+                // Inline expand: one argv per passthrough string; empty
+                // passthrough list contributes zero args.
+                for p in dctx.passthrough {
+                    out.push(p.clone());
+                }
+            } else {
+                let rendered = render(&mut tera, t, &ctx)
+                    .with_context(|| format!("rendering arg template: {t}"))?;
+                out.push(rendered);
+            }
+        }
+        Ok(out)
     }
 
     fn run_detached(&self, cmd: &mut StdCommand) -> Result<()> {
@@ -229,6 +252,26 @@ mod tests {
         // Literal text outside tags.
         assert!(!references_passthrough("--passthrough-mode=x"));
         assert!(!references_passthrough(""));
+    }
+
+    #[test]
+    fn is_passthrough_placeholder_matches_exact_forms_only() {
+        // Exact placeholder (possibly whitespace / strip marks).
+        assert!(is_passthrough_placeholder("{{ passthrough }}"));
+        assert!(is_passthrough_placeholder("{{passthrough}}"));
+        assert!(is_passthrough_placeholder("  {{ passthrough }}  "));
+        assert!(is_passthrough_placeholder("{{- passthrough -}}"));
+        assert!(is_passthrough_placeholder("{{-passthrough-}}"));
+        // NOT a placeholder — has extra content.
+        assert!(!is_passthrough_placeholder(
+            "{{ passthrough | join(sep=' ') }}"
+        ));
+        assert!(!is_passthrough_placeholder("prefix {{ passthrough }}"));
+        assert!(!is_passthrough_placeholder("{{ passthrough }} suffix"));
+        assert!(!is_passthrough_placeholder("{% for p in passthrough %}"));
+        // Not matching.
+        assert!(!is_passthrough_placeholder("{{ input }}"));
+        assert!(!is_passthrough_placeholder(""));
     }
 
     #[test]

--- a/src/backends/exec.rs
+++ b/src/backends/exec.rs
@@ -13,8 +13,10 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 use std::process::{Command as StdCommand, Stdio};
+use std::sync::OnceLock;
 
 use anyhow::{Context as _, Result, anyhow};
+use regex::Regex;
 use tracing::{debug, info};
 
 use crate::input::Input;
@@ -22,14 +24,38 @@ use crate::matcher::CaptureMap;
 use crate::platform;
 use crate::template::{Context, build_context, render};
 
+/// True when the joined args text references `{{ input }}` or any of the
+/// input-derived context vars (`file_*`, `url_*`). `cap.*` is intentionally
+/// excluded — captures are ambiguous enough that their presence can't be
+/// taken as proof of input reconstruction.
+fn references_input(text: &str) -> bool {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re =
+        RE.get_or_init(|| Regex::new(r"\{\{\s*(input|file_\w+|url_\w+)\b").expect("static regex"));
+    re.is_match(text)
+}
+
+/// True when the joined args text references `{{ passthrough }}` in any
+/// form (standalone, filtered, iterated).
+fn references_passthrough(text: &str) -> bool {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        Regex::new(r"\{\{\s*passthrough\b|\bfor\s+\w+\s+in\s+passthrough\b").expect("static regex")
+    });
+    re.is_match(text)
+}
+
 #[derive(Debug, Clone)]
 pub struct ExecBackend {
     pub command: String,
     pub args: Vec<String>,
     pub env: BTreeMap<String, String>,
-    /// Whether to append each input's display string as a trailing arg
-    /// after the rendered `args` list. Defaults to true.
-    pub append_inputs: bool,
+    /// `None` → auto (append when no args template references input/
+    /// file_*/url_*); `Some(true)` → always append; `Some(false)` → never.
+    pub append_inputs: Option<bool>,
+    /// Same semantics as `append_inputs` but keyed on `{{ passthrough }}`
+    /// references.
+    pub append_passthrough: Option<bool>,
     /// GUI handler hint — controls the detached-spawn code path on Windows
     /// (skip `cmd /c start` wrapper when true so no cmd window flashes).
     pub gui: bool,
@@ -54,12 +80,27 @@ impl ExecBackend {
     pub fn dispatch(&self, dctx: DispatchCtx<'_>) -> Result<()> {
         let rendered_args = self.render_args(&dctx)?;
 
+        // Auto-detect template references so "use {{ input }} in args"
+        // doesn't end up also pasting the raw value at the end. Scan the
+        // raw template strings (pre-render) so a reference inside a
+        // `{% if %}` branch still counts — false positives are preferable
+        // to double-insertion here.
+        let args_joined = self.args.join("\n");
+        let append_inputs = self
+            .append_inputs
+            .unwrap_or_else(|| !references_input(&args_joined));
+        let append_passthrough = self
+            .append_passthrough
+            .unwrap_or_else(|| !references_passthrough(&args_joined));
+
         let mut cmd = StdCommand::new(&self.command);
         cmd.args(&rendered_args);
-        for p in dctx.passthrough {
-            cmd.arg(p);
+        if append_passthrough {
+            for p in dctx.passthrough {
+                cmd.arg(p);
+            }
         }
-        if self.append_inputs {
+        if append_inputs {
             for i in dctx.inputs {
                 cmd.arg(i.display_string());
             }
@@ -73,7 +114,8 @@ impl ExecBackend {
             args = ?rendered_args,
             passthrough = ?dctx.passthrough,
             count = dctx.inputs.len(),
-            append_inputs = self.append_inputs,
+            append_inputs,
+            append_passthrough,
             sync = dctx.sync,
             mode = dctx.mode,
             "exec dispatch"
@@ -95,6 +137,7 @@ impl ExecBackend {
             rule_name: dctx.rule_name,
             vars: dctx.vars,
             cap: dctx.cap,
+            passthrough: dctx.passthrough,
         });
         let mut tera = crate::template::new_engine();
         self.args
@@ -133,6 +176,40 @@ mod tests {
     use std::path::PathBuf;
 
     #[test]
+    fn references_input_detects_input_and_derived_vars() {
+        assert!(references_input("{{ input }}"));
+        assert!(references_input("prefix {{  input  }} suffix"));
+        assert!(references_input("--file={{ file_path }}"));
+        assert!(references_input("--stem={{ file_stem }}"));
+        assert!(references_input("--host={{ url_host }}"));
+        assert!(references_input("--query={{ url_query }}"));
+        // cap is intentionally excluded.
+        assert!(!references_input("{{ cap.1 }}"));
+        assert!(!references_input("{{ cap.name }}"));
+        // Unrelated vars.
+        assert!(!references_input("{{ group }}"));
+        assert!(!references_input("{{ rule }}"));
+        assert!(!references_input("{{ command_name }}"));
+        // Empty / literal text.
+        assert!(!references_input(""));
+        assert!(!references_input("--flag"));
+        // Filter form.
+        assert!(references_input("{{ input | upper }}"));
+    }
+
+    #[test]
+    fn references_passthrough_detects_various_forms() {
+        assert!(references_passthrough("{{ passthrough }}"));
+        assert!(references_passthrough("{{ passthrough | join(sep=' ') }}"));
+        assert!(references_passthrough(
+            "{% for p in passthrough %}{{ p }}{% endfor %}"
+        ));
+        assert!(!references_passthrough("{{ input }}"));
+        assert!(!references_passthrough("{{ cap.1 }}"));
+        assert!(!references_passthrough(""));
+    }
+
+    #[test]
     fn renders_template_args_with_file_context() {
         let backend = ExecBackend {
             command: "echo".into(),
@@ -141,7 +218,8 @@ mod tests {
                 "--ext={{ file_ext }}".into(),
             ],
             env: BTreeMap::new(),
-            append_inputs: true,
+            append_inputs: Some(true),
+            append_passthrough: None,
             gui: false,
         };
         let inputs = vec![Input::File(PathBuf::from("/tmp/hello.rs"))];

--- a/src/backends/exec.rs
+++ b/src/backends/exec.rs
@@ -24,23 +24,28 @@ use crate::matcher::CaptureMap;
 use crate::platform;
 use crate::template::{Context, build_context, render};
 
-/// True when the joined args text references `{{ input }}` or any of the
-/// input-derived context vars (`file_*`, `url_*`). `cap.*` is intentionally
-/// excluded — captures are ambiguous enough that their presence can't be
-/// taken as proof of input reconstruction.
+/// True when any Tera tag (`{{ … }}` or `{% … %}`, including
+/// whitespace-stripping `{{- … -}}` / `{%- … -%}`) references `input` or
+/// any input-derived context var (`file_*`, `url_*`). `cap.*` is
+/// intentionally excluded — captures are ambiguous enough that their
+/// presence can't be taken as proof of input reconstruction.
 fn references_input(text: &str) -> bool {
     static RE: OnceLock<Regex> = OnceLock::new();
-    let re =
-        RE.get_or_init(|| Regex::new(r"\{\{\s*(input|file_\w+|url_\w+)\b").expect("static regex"));
+    let re = RE.get_or_init(|| {
+        Regex::new(r"\{[{%]-?[^{}]*?\b(input|file_\w+|url_\w+)\b[^{}]*?-?[%}]\}")
+            .expect("static regex")
+    });
     re.is_match(text)
 }
 
-/// True when the joined args text references `{{ passthrough }}` in any
-/// form (standalone, filtered, iterated).
+/// True when any Tera tag references `passthrough` — standalone
+/// (`{{ passthrough }}`), filtered (`{{ passthrough | join(...) }}`),
+/// iterated (`{% for p in passthrough %}`), or conditional
+/// (`{% if passthrough %}`). Covers whitespace-stripping tags too.
 fn references_passthrough(text: &str) -> bool {
     static RE: OnceLock<Regex> = OnceLock::new();
     let re = RE.get_or_init(|| {
-        Regex::new(r"\{\{\s*passthrough\b|\bfor\s+\w+\s+in\s+passthrough\b").expect("static regex")
+        Regex::new(r"\{[{%]-?[^{}]*?\bpassthrough\b[^{}]*?-?[%}]\}").expect("static regex")
     });
     re.is_match(text)
 }
@@ -177,12 +182,20 @@ mod tests {
 
     #[test]
     fn references_input_detects_input_and_derived_vars() {
+        // Standard expression tags.
         assert!(references_input("{{ input }}"));
         assert!(references_input("prefix {{  input  }} suffix"));
         assert!(references_input("--file={{ file_path }}"));
         assert!(references_input("--stem={{ file_stem }}"));
         assert!(references_input("--host={{ url_host }}"));
         assert!(references_input("--query={{ url_query }}"));
+        assert!(references_input("{{ input | upper }}"));
+        // Whitespace-stripping tags.
+        assert!(references_input("{{- input -}}"));
+        assert!(references_input("{{- file_path }}"));
+        // Block tags.
+        assert!(references_input("{% if input %}yes{% endif %}"));
+        assert!(references_input("{% if file_path != '' %}y{% endif %}"));
         // cap is intentionally excluded.
         assert!(!references_input("{{ cap.1 }}"));
         assert!(!references_input("{{ cap.name }}"));
@@ -190,22 +203,31 @@ mod tests {
         assert!(!references_input("{{ group }}"));
         assert!(!references_input("{{ rule }}"));
         assert!(!references_input("{{ command_name }}"));
-        // Empty / literal text.
+        // Literal text that happens to contain the word but outside any tag.
+        assert!(!references_input("--input-file"));
+        assert!(!references_input("pass an input here"));
+        // Empty.
         assert!(!references_input(""));
         assert!(!references_input("--flag"));
-        // Filter form.
-        assert!(references_input("{{ input | upper }}"));
     }
 
     #[test]
     fn references_passthrough_detects_various_forms() {
+        // Standard expression tags.
         assert!(references_passthrough("{{ passthrough }}"));
         assert!(references_passthrough("{{ passthrough | join(sep=' ') }}"));
+        // Whitespace-stripping.
+        assert!(references_passthrough("{{- passthrough -}}"));
+        // Block tags — conditionals and loops.
         assert!(references_passthrough(
             "{% for p in passthrough %}{{ p }}{% endfor %}"
         ));
+        assert!(references_passthrough("{% if passthrough %}yes{% endif %}"));
+        // Unrelated.
         assert!(!references_passthrough("{{ input }}"));
         assert!(!references_passthrough("{{ cap.1 }}"));
+        // Literal text outside tags.
+        assert!(!references_passthrough("--passthrough-mode=x"));
         assert!(!references_passthrough(""));
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,13 +50,25 @@ pub struct Target {
     pub args: BTreeMap<String, Vec<String>>,
     #[serde(default)]
     pub env: BTreeMap<String, String>,
-    /// When `true` (the default), the exec backend appends each input's
-    /// display string as a trailing positional arg after the rendered
-    /// `args` list. Set to `false` when your `args` already reference the
-    /// input via templates like `{{ input }}` / `{{ cap.N }}` and you
-    /// don't want the raw value passed again.
-    #[serde(default = "default_true")]
-    pub append_inputs: bool,
+    /// Controls whether the exec backend appends each input's display
+    /// string as a trailing positional arg after the rendered `args` list.
+    ///
+    /// - `None` / omitted (**auto**, the default): appended **unless** any
+    ///   `args` template references `{{ input }}` / `{{ file_* }}` /
+    ///   `{{ url_* }}` — in which case the trailing append is skipped so
+    ///   the same value isn't passed twice. `{{ cap.* }}` is **not** a
+    ///   signal (cap can be used for extraction unrelated to input
+    ///   reconstruction).
+    /// - `Some(true)`: force append regardless of templates.
+    /// - `Some(false)`: force skip regardless of templates.
+    #[serde(default)]
+    pub append_inputs: Option<bool>,
+    /// Controls whether passthrough-rule argv (`+42`, `-c :set …`, …) is
+    /// appended after the rendered `args` list. Same auto / true / false
+    /// semantics as [`Self::append_inputs`], but the auto trigger is
+    /// a `{{ passthrough }}` reference (any form).
+    #[serde(default)]
+    pub append_passthrough: Option<bool>,
     /// Set to `true` when the handler is a **GUI** application (neovide,
     /// nvim-qt, vscode, firefox, …). On Windows, detached spawns then use
     /// `CREATE_NO_WINDOW + DETACHED_PROCESS` instead of the default
@@ -68,10 +80,6 @@ pub struct Target {
     /// `cmd /c start` allocates.
     #[serde(default)]
     pub gui: bool,
-}
-
-fn default_true() -> bool {
-    true
 }
 
 impl Target {

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -239,7 +239,6 @@ fn plan_no_args(cli: &Cli, cfg: &ResolvedConfig) -> Result<Vec<Batch>> {
         .unwrap_or_else(|| format!("rule[{rule_idx}]"));
 
     let mut tera = new_engine();
-    let empty_passthrough: Vec<String> = Vec::new();
     let ctx_phase2 = build_context(Context {
         input: None,
         command: "",
@@ -248,7 +247,7 @@ fn plan_no_args(cli: &Cli, cfg: &ResolvedConfig) -> Result<Vec<Batch>> {
         rule_name: &rule_name,
         vars: &cfg.raw.vars,
         cap: &cap,
-        passthrough: &empty_passthrough,
+        passthrough: &[],
     });
 
     let group = resolve_group_with_ctx(cli, rule, &mut tera, &ctx_phase2)?;

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -239,6 +239,7 @@ fn plan_no_args(cli: &Cli, cfg: &ResolvedConfig) -> Result<Vec<Batch>> {
         .unwrap_or_else(|| format!("rule[{rule_idx}]"));
 
     let mut tera = new_engine();
+    let empty_passthrough: Vec<String> = Vec::new();
     let ctx_phase2 = build_context(Context {
         input: None,
         command: "",
@@ -247,6 +248,7 @@ fn plan_no_args(cli: &Cli, cfg: &ResolvedConfig) -> Result<Vec<Batch>> {
         rule_name: &rule_name,
         vars: &cfg.raw.vars,
         cap: &cap,
+        passthrough: &empty_passthrough,
     });
 
     let group = resolve_group_with_ctx(cli, rule, &mut tera, &ctx_phase2)?;
@@ -371,6 +373,7 @@ fn plan_batches(
             rule_name: &rule_name,
             vars: &cfg.raw.vars,
             cap: &cap,
+            passthrough: &[],
         });
 
         let group = resolve_group_with_ctx(cli, rule, &mut tera, &ctx)?;
@@ -412,6 +415,7 @@ fn plan_batches(
             rule_name: &rule_name,
             vars: &cfg.raw.vars,
             cap: &cap,
+            passthrough: &[],
         });
         let group = resolve_group_with_ctx(cli, rule, &mut tera, &ctx)?;
         let target_name = resolve_target_name(cli, rule, &mut tera, &ctx)?;
@@ -508,6 +512,7 @@ fn build_joined_batch(
         rule_name: &rule_name,
         vars: &cfg.raw.vars,
         cap: &cap,
+        passthrough: &[],
     });
     let group = resolve_group_with_ctx(cli, rule, tera, &ctx)?;
     let target_name = resolve_target_name(cli, rule, tera, &ctx)?;
@@ -615,6 +620,7 @@ async fn run_batch(cfg: &ResolvedConfig, batch: &Batch) -> Result<()> {
         rule_name: &batch.rule_name,
         vars: &cfg.raw.vars,
         cap: &batch.cap,
+        passthrough: &batch.passthrough_inputs,
     });
 
     let command =
@@ -703,6 +709,7 @@ fn run_exec(
         args: rendered_args.to_vec(),
         env: target.env.clone(),
         append_inputs: target.append_inputs,
+        append_passthrough: target.append_passthrough,
         gui: target.gui,
     };
     let dctx = ExecCtx {

--- a/src/template.rs
+++ b/src/template.rs
@@ -44,6 +44,11 @@ pub struct Context<'a> {
     /// Capture groups from the matched rule's regex; keyed by index
     /// (`"0"`, `"1"`, …) and by name. Empty when no capture / no match.
     pub cap: &'a crate::matcher::CaptureMap,
+    /// Raw argv strings from passthrough rules in this batch. Exposed in
+    /// Tera as `{{ passthrough }}` (an array — use `{{ passthrough | join(sep=' ') }}`
+    /// to stringify). Referencing it in any args template auto-suppresses
+    /// the trailing append (see `[todoke.<name>]` → `append_passthrough`).
+    pub passthrough: &'a [String],
 }
 
 fn strip_verbatim_str(s: &str) -> String {
@@ -182,6 +187,10 @@ pub fn build_context(c: Context<'_>) -> tera::Context {
     let cap_map: HashMap<String, String> = c.cap.clone().into_iter().collect();
     ctx.insert("cap", &cap_map);
 
+    // passthrough is an array. Use `{{ passthrough | join(sep=' ') }}` to
+    // inline it, or iterate with `{% for p in passthrough %}`.
+    ctx.insert("passthrough", c.passthrough);
+
     ctx
 }
 
@@ -192,6 +201,7 @@ mod tests {
 
     fn build(input: Option<&Input>, vars: &BTreeMap<String, toml::Value>) -> tera::Context {
         let cap = BTreeMap::new();
+        let passthrough: Vec<String> = Vec::new();
         build_context(Context {
             input,
             command: "",
@@ -200,6 +210,7 @@ mod tests {
             rule_name: "",
             vars,
             cap: &cap,
+            passthrough: &passthrough,
         })
     }
 
@@ -261,6 +272,7 @@ mod tests {
         cap.insert("0".into(), "issue:42".into());
         cap.insert("1".into(), "42".into());
         cap.insert("id".into(), "42".into());
+        let passthrough: Vec<String> = Vec::new();
         let ctx = build_context(Context {
             input: None,
             command: "",
@@ -269,6 +281,7 @@ mod tests {
             rule_name: "",
             vars: &BTreeMap::new(),
             cap: &cap,
+            passthrough: &passthrough,
         });
         let mut tera = new_engine();
         let out = render(&mut tera, "{{ cap.0 }} / {{ cap.1 }} / {{ cap.id }}", &ctx).unwrap();


### PR DESCRIPTION
## Summary

Symmetric auto-detection for \`append_inputs\` and \`append_passthrough\` based on whether args templates reference the corresponding context vars, plus \`{{ passthrough }}\` exposed on the Tera context so users can place passthrough argv anywhere in the handler command line.

### What changed

**Before**

- \`append_inputs\` was \`bool\` (default \`true\`). Users had to write \`append_inputs = false\` every time they referenced \`{{ input }}\` / \`{{ file_* }}\` in args, or the input got pasted twice.
- \`passthrough\` couldn't be placed inside args at all — it was hard-appended at the end. For handlers like gvim (\`--servername X --remote-silent <file>\`) where flags must come before the remote directive, the hard-append pasted \`+42\` after the filename and gvim mistook it for another file.

**After**

- \`{{ passthrough }}\` is a first-class Tera array in args. Render with \`| join(sep=' ')\`, iterate with \`{% for p in passthrough %}\`.
- \`append_inputs\` and the new \`append_passthrough\` are both \`Option<bool>\`:
  - omitted → **auto**
  - \`true\` → force append
  - \`false\` → force skip
- Auto trigger for \`append_inputs\`: any args template contains \`{{ input }}\` / \`{{ file_\w+ }}\` / \`{{ url_\w+ }}\`. \`cap.*\` is intentionally **not** a trigger (captures are ambiguous — user may extract unrelated strings).
- Auto trigger for \`append_passthrough\`: any args template contains \`{{ passthrough ... }}\` (standalone, filtered, or iterated).

### Motivating recipe (gvim)

\`\`\`toml
[todoke.gvim]
command = \"gvim\"
gui = true
[todoke.gvim.args]
default = [
  \"--servername\", \"{{ group | upper }}\",
  \"{{ passthrough | join(sep=' ') }}\",
  \"--remote-silent\", \"{{ input }}\",
]
\`\`\`

Auto-suppression kicks in twice here (both \`{{ input }}\` and \`{{ passthrough }}\` are referenced), and no double-insertion happens. Result: \`gvim --servername DEFAULT +42 --remote-silent foo.txt\` — exactly what gvim expects.

## Breaking

\`append_inputs\` default flips from \`true\` to **auto**. Explicit \`true\` / \`false\` settings continue to work identically. The only behavior change is: if you had args referencing \`{{ input }}\` but didn't set \`append_inputs = false\`, you were getting double-insertion — this PR silently fixes that. If you were relying on double-insertion (weird), set \`append_inputs = true\` to pin the old behavior.

## Test plan

- [x] \`cargo test\` — 57 unit + 11 integration pass (2 new unit tests for \`references_input\` / \`references_passthrough\`)
- [x] \`cargo make check\` — fmt / clippy / test / locked clean
- [ ] Manual gvim recipe smoke test
- [ ] Wait for Gemini + CodeRabbit reviews, address feedback, then merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for exec target gvim server reuse with configurable server name.
  * Introduced `passthrough` template variable for advanced templating workflows.
  * Enhanced `append_inputs` and new `append_passthrough` configurations with smart auto/true/false behavior to prevent duplicate value insertion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->