### PR TITLE
feat: optional `to` on passthrough rules (v1.3.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "todoke"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "todoke"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2024"
 rust-version = "1.85"
 description = "A rule-driven file and URL dispatcher: hands incoming paths (or URLs) to the right handler based on TOML-defined rules."

--- a/README.md
+++ b/README.md
@@ -267,12 +267,13 @@ a file path. Two ways to handle it:
 **Option A — `passthrough`** (simple; good for individual flag classes):
 
 ```toml
+# Generic flag catcher — no `to` because it just collects argv; the
+# target is decided by whichever *other* rule matches the input(s) in
+# the same group.
 [[rules]]
-name = "nvim-flag"
+name = "any-flag"
 match = '^[-+]'          # matches against the RAW argv, pre auto-detect
-to = "nvim-term"
-sync = true
-passthrough = true       # forward as-is to nvim's start-up argv
+passthrough = true
 
 [[rules]]
 name = "nvim-file"
@@ -282,7 +283,11 @@ sync = true
 ```
 
 `todoke +42 foo.txt bar.txt` now spawns `nvim +42 foo.txt bar.txt`
-(multi-file still works, `+42` rides along as a flag). For spaced
+(multi-file still works, `+42` rides along as a flag into the
+nvim-term batch). The flag rule is also target-agnostic — if you add
+another rule routing some inputs to a `code` target with the same
+group, `+42` will also ride into that batch. If `+42` arrives with no
+matching input batch in its group, it's dropped with a warning. For spaced
 values like `-c :set ft=md` where the flag and its value are separate
 argv items, use `consumes` to pull the next argv along:
 
@@ -457,7 +462,7 @@ A delivery target (the value behind a rule's `to = "<name>"`).
 | `name`    | string                    | `rule[N]`    | human-readable label (shown in `check`)      |
 | `match`   | regex string or `[regex]` | required     | pattern(s) matched against a string derived from the input: **file** = canonicalized absolute path with `/` separators (`\\?\` verbatim prefix stripped), **url** = the URL string as-is, **raw** = the argument string as-is. Anchors like `^foo$` only fire for the URL/raw cases unless you design the regex for absolute paths. |
 | `exclude` | regex string or `[regex]` | none         | when any `exclude` hits, the rule is skipped even if `match` hits — todoke falls through to the next rule |
-| `to`      | string (Tera-templated)   | required     | key into `[todoke.*]`                        |
+| `to`      | string (Tera-templated)   | required / optional | key into `[todoke.*]`. Required for normal and joined rules. **Optional for `passthrough = true` rules** — when omitted, the passthrough merges into any existing batch that shares its resolved `group` (target-agnostic), and is dropped with a warning if no such batch exists. Use for generic flag rules that should ride along with whoever else handles the input. |
 | `group`   | string                    | `"default"`  | instance identity (one nvim per group)       |
 | `mode`    | string                    | `"remote"`   | free-form; `"remote"` / `"new"` are reserved for neovim behavior, otherwise used only to pick `args.<mode>` |
 | `sync`    | bool                      | `false`      | `true` = block until handler exits           |

--- a/src/config.rs
+++ b/src/config.rs
@@ -115,7 +115,19 @@ pub struct Rule {
     pub exclude: Option<StringOrVec>,
     /// Name of a `[todoke.<name>]` entry to deliver the matched input to.
     /// Tera-templated — `to = "{{ vars.gui }}"` works.
-    pub to: String,
+    ///
+    /// **Optional only for `passthrough = true` rules.** A passthrough
+    /// rule with no `to` acts as "collect argv, let another rule decide
+    /// the target": at Phase 2b, the passthrough is merged into the
+    /// already-built batch that shares its resolved `group` (target
+    /// isn't required to match). If no such batch exists, the
+    /// passthrough is dropped with a warning. Useful for generic flag
+    /// rules like `match = '^[-+]'` that should ride along with whoever
+    /// the other rules decided to deliver to.
+    ///
+    /// Normal (non-passthrough) rules and joined rules still require `to`.
+    #[serde(default)]
+    pub to: Option<String>,
     #[serde(default)]
     pub group: Option<String>,
     /// Free-form mode string. For `kind = "neovim"` the reserved values
@@ -283,16 +295,28 @@ impl ResolvedConfig {
                     rule.name.as_deref().unwrap_or("<unnamed>"),
                 ));
             }
-            if is_template(&rule.to) {
-                continue;
-            }
-            if !raw.todoke.contains_key(&rule.to) {
-                return Err(anyhow!(
-                    "rule[{i}] ({}) references unknown todoke target '{}'. Known targets: {}",
-                    rule.name.as_deref().unwrap_or("<unnamed>"),
-                    rule.to,
-                    raw.todoke.keys().cloned().collect::<Vec<_>>().join(", ")
-                ));
+            match &rule.to {
+                None => {
+                    if !rule.passthrough {
+                        return Err(anyhow!(
+                            "rule[{i}] ({}) has no `to` — only `passthrough = true` rules may omit it (they merge into another rule's batch)",
+                            rule.name.as_deref().unwrap_or("<unnamed>"),
+                        ));
+                    }
+                }
+                Some(to) => {
+                    if is_template(to) {
+                        continue;
+                    }
+                    if !raw.todoke.contains_key(to) {
+                        return Err(anyhow!(
+                            "rule[{i}] ({}) references unknown todoke target '{}'. Known targets: {}",
+                            rule.name.as_deref().unwrap_or("<unnamed>"),
+                            to,
+                            raw.todoke.keys().cloned().collect::<Vec<_>>().join(", ")
+                        ));
+                    }
+                }
             }
         }
 
@@ -620,6 +644,35 @@ mod tests {
         "#;
         let err = load_from_str(text).unwrap_err();
         assert!(err.to_string().contains("consumes_until"), "got: {err}");
+    }
+
+    #[test]
+    fn passthrough_rule_can_omit_to() {
+        let text = r#"
+            [todoke.a]
+            command = "echo"
+
+            [[rules]]
+            name = "any-flag"
+            match = '^-'
+            passthrough = true
+        "#;
+        let cfg = load_from_str(text).expect("passthrough rule should allow omitted `to`");
+        assert!(cfg.raw.rules[0].to.is_none());
+    }
+
+    #[test]
+    fn non_passthrough_rule_requires_to() {
+        let text = r#"
+            [todoke.a]
+            command = "echo"
+
+            [[rules]]
+            name = "orphan"
+            match = '.*'
+        "#;
+        let err = load_from_str(text).unwrap_err();
+        assert!(err.to_string().contains("has no `to`"), "got: {err}");
     }
 
     #[test]

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -99,23 +99,35 @@ pub async fn doctor(cli: &Cli) -> Result<()> {
 
     for (i, rule) in cfg.raw.rules.iter().enumerate() {
         let name = rule.name.as_deref().unwrap_or("<unnamed>");
-        if !rule.to.contains("{{") && !rule.to.contains("{%") {
-            if !cfg.raw.todoke.contains_key(&rule.to) {
+        match rule.to.as_deref() {
+            None => {
                 println!(
-                    "{} {}: to {} is not defined in [todoke.*]",
-                    styled("error", level_error()),
+                    "{}  {}: no {} — {} rule, merges into another rule's batch by group",
+                    styled("info", level_info()),
                     styled(format!("rule[{i}] ({name})"), bold()),
-                    styled(format!("'{}'", rule.to), accent()),
+                    styled("to", accent()),
+                    styled("passthrough", dim()),
                 );
-                issues += 1;
             }
-        } else {
-            println!(
-                "{}  {}: to {} is a Tera template, resolved at dispatch time",
-                styled("info", level_info()),
-                styled(format!("rule[{i}] ({name})"), bold()),
-                styled(format!("'{}'", rule.to), accent()),
-            );
+            Some(to) if !to.contains("{{") && !to.contains("{%") => {
+                if !cfg.raw.todoke.contains_key(to) {
+                    println!(
+                        "{} {}: to {} is not defined in [todoke.*]",
+                        styled("error", level_error()),
+                        styled(format!("rule[{i}] ({name})"), bold()),
+                        styled(format!("'{to}'"), accent()),
+                    );
+                    issues += 1;
+                }
+            }
+            Some(to) => {
+                println!(
+                    "{}  {}: to {} is a Tera template, resolved at dispatch time",
+                    styled("info", level_info()),
+                    styled(format!("rule[{i}] ({name})"), bold()),
+                    styled(format!("'{to}'"), accent()),
+                );
+            }
         }
     }
 
@@ -251,7 +263,9 @@ fn plan_no_args(cli: &Cli, cfg: &ResolvedConfig) -> Result<Vec<Batch>> {
     });
 
     let group = resolve_group_with_ctx(cli, rule, &mut tera, &ctx_phase2)?;
-    let target_name = resolve_target_name(cli, rule, &mut tera, &ctx_phase2)?;
+    let target_name = resolve_target_name(cli, rule, &mut tera, &ctx_phase2)?.ok_or_else(|| {
+        anyhow!("no-args rule must have `to` (validation should have caught this)")
+    })?;
 
     Ok(vec![Batch {
         target_name,
@@ -376,7 +390,9 @@ fn plan_batches(
         });
 
         let group = resolve_group_with_ctx(cli, rule, &mut tera, &ctx)?;
-        let target_name = resolve_target_name(cli, rule, &mut tera, &ctx)?;
+        let target_name = resolve_target_name(cli, rule, &mut tera, &ctx)?.ok_or_else(|| {
+            anyhow!("non-passthrough rule must have `to` (validation should have caught this)")
+        })?;
 
         let key = BatchKey {
             target: target_name.clone(),
@@ -417,41 +433,85 @@ fn plan_batches(
             passthrough: &[],
         });
         let group = resolve_group_with_ctx(cli, rule, &mut tera, &ctx)?;
-        let target_name = resolve_target_name(cli, rule, &mut tera, &ctx)?;
+        let target_name_opt = resolve_target_name(cli, rule, &mut tera, &ctx)?;
 
-        let matching_key = groups
-            .keys()
-            .find(|k| k.target == target_name && k.group == group)
-            .cloned();
-
-        let key = match matching_key {
-            Some(k) => {
-                let batch = groups.get(&k).expect("key came from groups");
-                if batch.mode != rule.mode || batch.sync != rule.sync {
-                    warn!(
-                        rule = %rule_name,
-                        batch_rule = %batch.rule_name,
-                        target = %target_name,
-                        group = %group,
-                        batch_mode = %batch.mode,
-                        batch_sync = batch.sync,
-                        rule_mode = %rule.mode,
-                        rule_sync = rule.sync,
-                        "passthrough rule's mode/sync differs from the batch it's attaching to; batch values win",
-                    );
+        // Two flavors of passthrough merge:
+        //
+        // (a) `to` is specified — find/create a batch with matching
+        //     (target, group). Fall back to a standalone passthrough batch
+        //     if none exists.
+        // (b) `to` is omitted — the rule is a "pure collector". Find ANY
+        //     batch whose group matches and merge there. If none exists,
+        //     drop the passthrough with a warning (no fallback batch).
+        //     If multiple group-matching batches exist, merge into the
+        //     first (BTreeMap order) and warn about the ambiguity.
+        let key = match &target_name_opt {
+            Some(target_name) => {
+                let matching_key = groups
+                    .keys()
+                    .find(|k| k.target == *target_name && k.group == group)
+                    .cloned();
+                match matching_key {
+                    Some(k) => {
+                        let batch = groups.get(&k).expect("key came from groups");
+                        if batch.mode != rule.mode || batch.sync != rule.sync {
+                            warn!(
+                                rule = %rule_name,
+                                batch_rule = %batch.rule_name,
+                                target = %target_name,
+                                group = %group,
+                                batch_mode = %batch.mode,
+                                batch_sync = batch.sync,
+                                rule_mode = %rule.mode,
+                                rule_sync = rule.sync,
+                                "passthrough rule's mode/sync differs from the batch it's attaching to; batch values win",
+                            );
+                        }
+                        k
+                    }
+                    None => BatchKey {
+                        target: target_name.clone(),
+                        group: group.clone(),
+                        mode: rule.mode.clone(),
+                        sync: rule.sync,
+                    },
                 }
-                k
             }
-            None => BatchKey {
-                target: target_name.clone(),
-                group: group.clone(),
-                mode: rule.mode.clone(),
-                sync: rule.sync,
-            },
+            None => {
+                // `to`-less: merge by group only.
+                let candidates: Vec<BatchKey> = groups
+                    .keys()
+                    .filter(|k| k.group == group)
+                    .cloned()
+                    .collect();
+                match candidates.len() {
+                    0 => {
+                        warn!(
+                            rule = %rule_name,
+                            group = %group,
+                            dropped = ?consumed,
+                            "passthrough rule has no `to` and no batch in this group — dropping argv",
+                        );
+                        continue;
+                    }
+                    1 => candidates.into_iter().next().unwrap(),
+                    n => {
+                        let first = candidates.into_iter().next().unwrap();
+                        warn!(
+                            rule = %rule_name,
+                            group = %group,
+                            candidates = n,
+                            chosen_target = %first.target,
+                            "passthrough rule has no `to` and multiple batches in this group; merging into first — set `to` explicitly to disambiguate",
+                        );
+                        first
+                    }
+                }
+            }
         };
 
         let batch = groups.entry(key).or_insert_with(|| Batch {
-            target_name: target_name.clone(),
+            target_name: target_name_opt.clone().unwrap_or_default(),
             group: group.clone(),
             mode: rule.mode.clone(),
             sync: rule.sync,
@@ -514,7 +574,9 @@ fn build_joined_batch(
         passthrough: &[],
     });
     let group = resolve_group_with_ctx(cli, rule, tera, &ctx)?;
-    let target_name = resolve_target_name(cli, rule, tera, &ctx)?;
+    let target_name = resolve_target_name(cli, rule, tera, &ctx)?.ok_or_else(|| {
+        anyhow!("joined rule must have `to` (validation should have caught this)")
+    })?;
 
     Ok(vec![Batch {
         target_name,
@@ -571,16 +633,25 @@ fn resolve_group_with_ctx(
     }
 }
 
+/// `Ok(Some(name))` when a target is selected (CLI override or rendered
+/// `rule.to`). `Ok(None)` only for `passthrough = true` rules that omit
+/// `to` — the caller (Phase 2b) is responsible for picking a merge-target
+/// by group.
 fn resolve_target_name(
     cli: &Cli,
     rule: &Rule,
     tera: &mut tera::Tera,
     ctx: &tera::Context,
-) -> Result<String> {
+) -> Result<Option<String>> {
     if let Some(e) = cli.editor.clone() {
-        return Ok(e);
+        return Ok(Some(e));
     }
-    render(tera, &rule.to, ctx).context("rendering rule.to template")
+    match &rule.to {
+        None => Ok(None),
+        Some(tmpl) => render(tera, tmpl, ctx)
+            .context("rendering rule.to template")
+            .map(Some),
+    }
 }
 
 async fn run_plan(cfg: &ResolvedConfig, plan: Vec<Batch>) -> Result<()> {

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -478,40 +478,40 @@ fn plan_batches(
                 }
             }
             None => {
-                // `to`-less: merge by group only.
-                let candidates: Vec<BatchKey> = groups
-                    .keys()
-                    .filter(|k| k.group == group)
-                    .cloned()
-                    .collect();
-                match candidates.len() {
-                    0 => {
-                        warn!(
-                            rule = %rule_name,
-                            group = %group,
-                            dropped = ?consumed,
-                            "passthrough rule has no `to` and no batch in this group — dropping argv",
-                        );
-                        continue;
-                    }
-                    1 => candidates.into_iter().next().unwrap(),
-                    n => {
-                        let first = candidates.into_iter().next().unwrap();
-                        warn!(
-                            rule = %rule_name,
-                            group = %group,
-                            candidates = n,
-                            chosen_target = %first.target,
-                            "passthrough rule has no `to` and multiple batches in this group; merging into first — set `to` explicitly to disambiguate",
-                        );
-                        first
-                    }
+                // `to`-less: merge by group only. Iterate once, peek first
+                // match and count the rest — no intermediate Vec.
+                let mut matching = groups.keys().filter(|k| k.group == group);
+                let Some(first) = matching.next().cloned() else {
+                    warn!(
+                        rule = %rule_name,
+                        group = %group,
+                        dropped = ?consumed,
+                        "passthrough rule has no `to` and no batch in this group — dropping argv",
+                    );
+                    continue;
+                };
+                let extra = matching.count();
+                if extra > 0 {
+                    warn!(
+                        rule = %rule_name,
+                        group = %group,
+                        candidates = extra + 1,
+                        chosen_target = %first.target,
+                        "passthrough rule has no `to` and multiple batches in this group; merging into first — set `to` explicitly to disambiguate",
+                    );
                 }
+                first
             }
         };
 
         let batch = groups.entry(key).or_insert_with(|| Batch {
-            target_name: target_name_opt.clone().unwrap_or_default(),
+            // to-less passthrough never hits this branch: it either
+            // drops (no match) or merges into an existing key (first
+            // match). `or_insert_with` only fires on the `Some(to)`
+            // new-batch fallback, where target_name_opt is guaranteed Some.
+            target_name: target_name_opt
+                .clone()
+                .expect("or_insert_with only fires for Some(to) path"),
             group: group.clone(),
             mode: rule.mode.clone(),
             sync: rule.sync,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -20,13 +20,20 @@ fn write_file(path: &Path, contents: &str) {
 }
 
 fn temp_dir() -> PathBuf {
+    // Windows' SystemTime has ~100ns resolution, and cargo test runs
+    // integration tests in parallel. Nanos alone collided on CI and let
+    // one test's config overwrite another's. Atomic counter + pid makes
+    // it deterministically unique without needing a uuid dep.
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
     let base = std::env::temp_dir().join("todoke-test");
-    // unique-ish per test via nano timestamp
     let stamp = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_nanos();
-    let d = base.join(stamp.to_string());
+    let pid = std::process::id();
+    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let d = base.join(format!("{stamp}-{pid}-{seq}"));
     std::fs::create_dir_all(&d).unwrap();
     d
 }


### PR DESCRIPTION
## Summary

Makes \`rule.to\` optional on passthrough rules so a single generic flag catcher can ride along on any target instead of being duplicated per target.

### Before

\`\`\`toml
[[rules]]
name = \"any-flag-gui\"
match = '^[-+]'
to = \"gui\"
passthrough = true

[[rules]]
name = \"any-flag-code\"
match = '^[-+]'
to = \"code\"
passthrough = true
\`\`\`

### After

\`\`\`toml
[[rules]]
name = \"any-flag\"
match = '^[-+]'
passthrough = true         # no \`to\` — merges with whichever batch the group resolves to
\`\`\`

## Semantics

Phase 2b merges a to-less passthrough's argv into an existing batch that shares the rule's resolved \`group\` (target-agnostic):

| group-matching batches | behavior |
|---|---|
| 0 | warn + drop the argv (no fallback batch) |
| 1 | merge there |
| 2+ | merge into the first (BTreeMap order) + warn — user should disambiguate with explicit \`to\` |

\`to\` stays **required** for normal and joined rules (compile-time error if omitted).

## Why group-only, not (target, group)

If \`to\` were used for the match, a to-less rule would reduce to \"match anything\" ⇒ always fallback to creating a standalone batch ⇒ same old duplication problem. Gating by \`group\` is the minimal change that captures the intent \"this rule collects argv; another rule picks the target\".

Picked \`group\` over other options (e.g. \"first batch regardless of group\" / \"all batches with flag replicated\") because:

- **Semantic fit**: \`group\` is the config-level \"work context\" identifier.
- **Predictability**: order-independent (the all-file-batches-first alternative would make \`+42\` attach to whichever input parsed first — too magical).
- **Disambiguation path**: if multiple batches in the same group exist, warn + explicit \`to\` is a clear escape hatch.

## Changes

- \`src/config.rs\`: \`Rule.to\` → \`Option<String>\`. Compile validation errors when \`to\` is absent on non-passthrough rules.
- \`src/dispatcher.rs\`:
  - \`resolve_target_name\` now returns \`Result<Option<String>>\`.
  - Phase 2b branches: \`Some(to)\` keeps the old (target, group) merge + fallback-batch path; \`None\` does the new group-only merge with the 0/1/2+ handling above.
  - \`doctor\` prints an info line for to-less passthrough rules.
- README: \`[[rules]]\` table row for \`to\` updated, editor-flag recipe rewritten with a single to-less \`any-flag\` rule.

## Test plan

- [x] \`cargo test\` — 60 unit + 11 integration pass (2 new config tests: to-less passthrough accepted, to-less normal rejected)
- [x] Manual dry-run verified:
  - \`+42 foo.txt\` → \`+42\` merges into the default-file batch
  - \`+42\` alone → warn + drop, empty plan
- [x] \`cargo make check\` — fmt / clippy / test / locked all clean
- [ ] Wait for Gemini + CodeRabbit review, address feedback, then merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)