### PR TITLE
feat: windows-subsystem release + parent console attach (v1.4.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -67,7 +67,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -334,7 +334,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -361,7 +361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -802,7 +802,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -811,7 +811,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1264,7 +1264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1391,7 +1391,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
- "windows-sys 0.60.2",
+ "windows-sys",
  "winresource",
 ]
 
@@ -1409,7 +1409,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1675,7 +1675,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1739,86 +1739,12 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -67,7 +67,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -334,7 +334,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -361,7 +361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -802,7 +802,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -811,7 +811,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1264,7 +1264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "todoke"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1391,6 +1391,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "windows-sys 0.60.2",
  "winresource",
 ]
 
@@ -1408,7 +1409,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1674,7 +1675,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1738,12 +1739,86 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "todoke"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2024"
 rust-version = "1.85"
 description = "A rule-driven file and URL dispatcher: hands incoming paths (or URLs) to the right handler based on TOML-defined rules."
@@ -46,6 +46,12 @@ tokio = { version = "1.52.1", features = ["full"] }
 toml = "1.1.2"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.60", features = [
+    "Win32_Foundation",
+    "Win32_System_Console",
+] }
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.60", features = [
+windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_System_Console",
 ] }

--- a/src/console_attach.rs
+++ b/src/console_attach.rs
@@ -1,0 +1,55 @@
+//! Windows-only: attach to the parent process's console on startup and
+//! rebind stdio so `println!` / `tracing` reaches the terminal that
+//! launched us.
+//!
+//! Why: release builds use `windows_subsystem = "windows"` so explorer
+//! / shortcut / file-association launches don't flash a transient
+//! console window. A windows-subsystem exe starts with no attached
+//! console at all, so terminal launches need us to:
+//!
+//! 1. `AttachConsole(ATTACH_PARENT_PROCESS)` — grab the launching
+//!    terminal's console if it has one.
+//! 2. Re-open `CONOUT$` / `CONIN$` and `SetStdHandle` them so stdio
+//!    actually points somewhere Rust's `println!` / reads can use.
+//!
+//! When launched from explorer `AttachConsole` returns 0 and this whole
+//! function is a no-op (stdio stays null — exactly what we want).
+
+use std::fs::OpenOptions;
+use std::os::windows::io::AsRawHandle;
+
+use windows_sys::Win32::System::Console::{
+    ATTACH_PARENT_PROCESS, AttachConsole, STD_ERROR_HANDLE, STD_HANDLE, STD_INPUT_HANDLE,
+    STD_OUTPUT_HANDLE, SetStdHandle,
+};
+
+pub fn attach_parent_console() {
+    // SAFETY: Win32 API call; the return value distinguishes success (1)
+    // from no-parent-console (0).
+    if unsafe { AttachConsole(ATTACH_PARENT_PROCESS) } == 0 {
+        return;
+    }
+    rebind("CONOUT$", STD_OUTPUT_HANDLE, true);
+    rebind("CONOUT$", STD_ERROR_HANDLE, true);
+    rebind("CONIN$", STD_INPUT_HANDLE, false);
+}
+
+/// Open the console device and wire it to one of the standard handles.
+/// The opened `File` is deliberately `mem::forget`-ed: dropping it would
+/// close the HANDLE we just gave to `SetStdHandle`.
+fn rebind(path: &str, which: STD_HANDLE, write: bool) {
+    let mut opts = OpenOptions::new();
+    opts.read(true);
+    if write {
+        opts.write(true);
+    }
+    let Ok(file) = opts.open(path) else {
+        return;
+    };
+    let handle = file.as_raw_handle();
+    // SAFETY: Win32 call, handle is a valid OS handle obtained above.
+    unsafe {
+        SetStdHandle(which, handle as _);
+    }
+    std::mem::forget(file);
+}

--- a/src/console_attach.rs
+++ b/src/console_attach.rs
@@ -9,18 +9,33 @@
 //!
 //! 1. `AttachConsole(ATTACH_PARENT_PROCESS)` — grab the launching
 //!    terminal's console if it has one.
-//! 2. Re-open `CONOUT$` / `CONIN$` and `SetStdHandle` them so stdio
-//!    actually points somewhere Rust's `println!` / reads can use.
+//! 2. For each standard handle that's currently **empty** (null),
+//!    re-open `CONOUT$` / `CONIN$` and wire it in with `SetStdHandle`.
 //!
-//! When launched from explorer `AttachConsole` returns 0 and this whole
-//! function is a no-op (stdio stays null — exactly what we want).
+//! The "currently empty" check is load-bearing. Shell redirection
+//! (`todoke --version > out.txt`, `todoke | clip`) leaves a real
+//! redirected handle in place even before we attach. Clobbering it
+//! would break piping and redirection — so we only touch handles that
+//! would otherwise be null.
+//!
+//! When launched from explorer `AttachConsole` returns 0 and this
+//! whole function is a no-op (stdio stays null — exactly what we want).
+//!
+//! **Call ordering is load-bearing.** Rust's `io::stdout()` /
+//! `io::stderr()` / `io::stdin()` cache the handle on first use. If
+//! anything writes to stdio *before* `attach_parent_console()` runs,
+//! the null handle gets cached and the `SetStdHandle` calls here
+//! become no-ops from Rust's perspective. `main()` invokes this as
+//! the first statement; don't introduce earlier stdio usage (panic
+//! hooks, static initializers, etc.) without re-thinking this.
 
 use std::fs::OpenOptions;
-use std::os::windows::io::AsRawHandle;
+use std::os::windows::io::IntoRawHandle;
 
+use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
 use windows_sys::Win32::System::Console::{
-    ATTACH_PARENT_PROCESS, AttachConsole, STD_ERROR_HANDLE, STD_HANDLE, STD_INPUT_HANDLE,
-    STD_OUTPUT_HANDLE, SetStdHandle,
+    ATTACH_PARENT_PROCESS, AttachConsole, GetStdHandle, STD_ERROR_HANDLE, STD_HANDLE,
+    STD_INPUT_HANDLE, STD_OUTPUT_HANDLE, SetStdHandle,
 };
 
 pub fn attach_parent_console() {
@@ -29,15 +44,23 @@ pub fn attach_parent_console() {
     if unsafe { AttachConsole(ATTACH_PARENT_PROCESS) } == 0 {
         return;
     }
-    rebind("CONOUT$", STD_OUTPUT_HANDLE, true);
-    rebind("CONOUT$", STD_ERROR_HANDLE, true);
-    rebind("CONIN$", STD_INPUT_HANDLE, false);
+    maybe_rebind("CONOUT$", STD_OUTPUT_HANDLE, true);
+    maybe_rebind("CONOUT$", STD_ERROR_HANDLE, true);
+    maybe_rebind("CONIN$", STD_INPUT_HANDLE, false);
 }
 
-/// Open the console device and wire it to one of the standard handles.
-/// The opened `File` is deliberately `mem::forget`-ed: dropping it would
-/// close the HANDLE we just gave to `SetStdHandle`.
-fn rebind(path: &str, which: STD_HANDLE, write: bool) {
+/// Re-open the console device and install it as `which` — but ONLY if
+/// `which` is currently null. A non-null existing handle means the
+/// caller redirected it (e.g. `todoke > out.txt`), and we must leave
+/// that alone.
+fn maybe_rebind(path: &str, which: STD_HANDLE, write: bool) {
+    // SAFETY: Win32 API call.
+    let existing = unsafe { GetStdHandle(which) };
+    if !existing.is_null() && existing != INVALID_HANDLE_VALUE {
+        // Redirection already in place — respect it.
+        return;
+    }
+
     let mut opts = OpenOptions::new();
     opts.read(true);
     if write {
@@ -46,10 +69,18 @@ fn rebind(path: &str, which: STD_HANDLE, write: bool) {
     let Ok(file) = opts.open(path) else {
         return;
     };
-    let handle = file.as_raw_handle();
-    // SAFETY: Win32 call, handle is a valid OS handle obtained above.
-    unsafe {
-        SetStdHandle(which, handle as _);
+
+    // Transfer ownership of the HANDLE out of `file` so its Drop won't
+    // close what we just handed to SetStdHandle. If SetStdHandle
+    // fails, we own an orphan HANDLE and must close it ourselves.
+    let handle = file.into_raw_handle();
+    // SAFETY: Win32 call; `handle` is a valid OS HANDLE we just took
+    // ownership of via IntoRawHandle.
+    let ok = unsafe { SetStdHandle(which, handle as _) };
+    if ok == 0 {
+        // SAFETY: `handle` was valid and is still owned by us.
+        unsafe {
+            CloseHandle(handle as _);
+        }
     }
-    std::mem::forget(file);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,15 @@ use cli::{Cli, Command};
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // MUST be the very first thing in main().
+    //
+    // Rust's io::stdout / io::stderr / io::stdin cache their OS handle
+    // on first use. Any stdio access before this runs would freeze the
+    // null handle in place and the SetStdHandle calls below would
+    // become no-ops for Rust's stdio. Keep this at the top; don't
+    // introduce earlier stdio writers (panic hooks, static init, etc.)
+    // without rechecking this invariant.
+    //
     // On Windows, attach to the parent terminal (if any) so logs and
     // stdout reach whoever launched us from PowerShell / cmd. When
     // launched from explorer there is no parent console — the call

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,17 @@
+// Release builds on Windows use the "windows" subsystem so launching
+// todoke from explorer / shortcut / file association doesn't flash a
+// transient console window. Debug builds stay on the default "console"
+// subsystem to keep dev ergonomics unchanged.
+#![cfg_attr(all(windows, not(debug_assertions)), windows_subsystem = "windows")]
+
 use anyhow::Result;
 use clap::{CommandFactory, Parser};
 
 mod backends;
 mod cli;
 mod config;
+#[cfg(windows)]
+mod console_attach;
 mod dispatcher;
 mod input;
 mod matcher;
@@ -15,6 +23,13 @@ use cli::{Cli, Command};
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // On Windows, attach to the parent terminal (if any) so logs and
+    // stdout reach whoever launched us from PowerShell / cmd. When
+    // launched from explorer there is no parent console — the call
+    // is a no-op and stdio sinks silently.
+    #[cfg(windows)]
+    console_attach::attach_parent_console();
+
     let mut cli = Cli::parse();
 
     tracing_subscriber::fmt()


### PR DESCRIPTION
## Summary

Kills the transient console flash that still appeared on Windows when todoke was launched via explorer / shortcut / file association, even with \`target.gui = true\` on the target. Root cause: the parent todoke.exe itself is a console-subsystem binary, so Windows allocates a fresh console **before any todoke code runs**. No runtime gate could suppress that.

### What changed

- **Release builds on Windows** now use \`windows_subsystem = \"windows\"\`. No console is allocated at launch → no flash on explorer / shortcut / file-association. Debug builds stay on the default console subsystem so \`cargo run\` / \`cargo test\` keep their usual output.
- **Startup** (Windows only) calls \`AttachConsole(ATTACH_PARENT_PROCESS)\` and re-opens \`CONOUT\$\` / \`CONIN\$\` onto the standard handles. Terminal launches (PowerShell / cmd / \`\$EDITOR=todoke\`) get \`println!\` / \`tracing\` / CLI output in the launching terminal exactly as before. Explorer launches have no parent console — the attach is a no-op and stdio sinks silently, which is the desired behavior.
- **New module** \`src/console_attach.rs\` with a single \`attach_parent_console()\` entry point, gated on \`#[cfg(windows)]\`.
- **Cargo.toml**: \`windows-sys = \"0.60\"\` under \`[target.'cfg(windows)'.dependencies]\` with only the two features we touch (\`Win32_Foundation\`, \`Win32_System_Console\`). Avoided \`Win32_Storage_FileSystem\` by opening the console devices via \`std::fs::OpenOptions::open(\"CONOUT\$\")\` + \`SetStdHandle\` instead of calling \`CreateFileW\` directly.

### Why not test it automatically?

Windows console-attach behavior hinges on host-process state (whether the launcher has a real console) and Win32 primitives that can't be mocked cleanly in unit tests. The regression that prompted this (transient black flash) is also visually-obvious the moment it comes back. Same reasoning as \`spawn_detached\` coverage on PR #26.

### Manual verification (Windows 11)

- [x] PowerShell: \`target/release/todoke.exe --version\` prints \`todoke 1.4.0\`
- [x] Double-clicking a file associated with todoke: no console flash before the target opens
- [x] MSYS bash (non-native console): release build's output goes silent — expected, since the pty parent has no real console
- [x] Debug build (`cargo run`): unaffected, output visible as before

## Test plan

- [x] \`cargo test\` — existing tests unchanged; console_attach has no automated coverage (see above)
- [x] \`cargo make check\` — fmt / clippy / test / locked clean
- [ ] CI on all three OSes (unix paths unaffected — attach module is \`cfg(windows)\`)
- [ ] Gemini + CodeRabbit review, address feedback, then merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Windows console support: the application now properly attaches to the parent terminal, ensuring output is visible when launched from command line

* **Chores**
  * Version bumped from 1.3.0 to 1.4.0
  * Windows subsystem optimization for release builds
  * Added Windows platform-specific system dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->