### PR TITLE
feat!: streamline CLI surface — drop duplicates, rename flags (v2.0.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,6 +1383,7 @@ dependencies = [
  "owo-colors",
  "regex",
  "serde",
+ "shlex",
  "supports-color",
  "tera",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "todoke"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ nvim-rs = { version = "0.9.2", features = ["use_tokio"] }
 owo-colors = "4.3.0"
 regex = "1.12.3"
 serde = { version = "1.0.228", features = ["derive"] }
+shlex = "1.3"
 supports-color = "3.0.2"
 tera = "1.20.1"
 url = "2.5.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "todoke"
-version = "1.4.0"
+version = "2.0.0"
 edition = "2024"
 rust-version = "1.85"
 description = "A rule-driven file and URL dispatcher: hands incoming paths (or URLs) to the right handler based on TOML-defined rules."

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,11 +46,11 @@ pub struct Cli {
     pub config: Option<PathBuf>,
 
     #[arg(
-        long = "todoke-editor",
+        long = "todoke-to",
         value_name = "NAME",
-        help = "Bypass rules, force handler"
+        help = "Bypass rules, force the target (entry under [todoke.<name>])"
     )]
-    pub editor: Option<String>,
+    pub to: Option<String>,
 
     #[arg(
         long = "todoke-group",
@@ -66,12 +66,6 @@ pub struct Cli {
         help = "Force how each argument is classified (skip auto-detection)"
     )]
     pub as_kind: Option<InputKind>,
-
-    #[arg(
-        long = "todoke-dry-run",
-        help = "Resolve rules and log decisions without dispatching"
-    )]
-    pub dry_run: bool,
 
     #[arg(
         long = "todoke-verbose",
@@ -115,10 +109,17 @@ pub enum Command {
         all: bool,
     },
 
-    #[command(about = "Dry-run: show which rule matches each file without dispatching")]
+    #[command(about = "Dry-run: show the dispatch plan for the given inputs without executing")]
     Check {
-        #[arg(value_name = "FILES", required = true)]
-        files: Vec<PathBuf>,
+        // Same shape as the top-level positional: hyphen-shaped argv
+        // (`-f`, `+42`, `-sfoo`, …) must flow through as inputs without
+        // clap treating them as flags to `check` itself.
+        #[arg(
+            value_name = "INPUTS",
+            trailing_var_arg = true,
+            allow_hyphen_values = true
+        )]
+        inputs: Vec<PathBuf>,
     },
 
     #[command(

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,29 +1,194 @@
-use anyhow::{Result, bail};
+use std::path::Path;
+use std::process::Command as StdCommand;
+
+use anyhow::{Context, Result, anyhow, bail};
 use clap::Subcommand;
+
+use crate::config;
 
 #[derive(Subcommand, Debug)]
 pub enum ConfigSub {
-    #[command(about = "Print resolved config file path")]
+    #[command(about = "Print the resolved config file path")]
     Path,
-    #[command(about = "Open the config file through todoke itself")]
+    #[command(
+        about = "Write the embedded default config if no file exists yet (idempotent; never overwrites)"
+    )]
+    Init,
+    #[command(about = "Open the config file in $EDITOR (writes the default first if missing)")]
     Edit,
-    #[command(about = "Validate TOML syntax and Tera templates")]
-    Validate,
-    #[command(about = "Print the loaded config")]
+    #[command(about = "Print the loaded config TOML")]
     Show {
         #[arg(
             long,
-            help = "Show templates fully resolved using an empty file context"
+            help = "Print the TOML after Tera pre-render (no rule/file context is provided)"
         )]
-        resolved: bool,
+        rendered: bool,
     },
 }
 
-pub async fn run(sub: ConfigSub) -> Result<()> {
+pub async fn run(sub: ConfigSub, explicit_config: Option<&Path>) -> Result<()> {
     match sub {
-        ConfigSub::Path => bail!("not implemented yet"),
-        ConfigSub::Edit => bail!("not implemented yet"),
-        ConfigSub::Validate => bail!("not implemented yet"),
-        ConfigSub::Show { resolved: _ } => bail!("not implemented yet"),
+        ConfigSub::Path => {
+            let path = config::resolve_path(explicit_config)?;
+            println!("{}", path.display());
+            Ok(())
+        }
+        ConfigSub::Init => init(explicit_config),
+        ConfigSub::Edit => edit(explicit_config),
+        ConfigSub::Show { rendered } => show(explicit_config, rendered),
+    }
+}
+
+fn init(explicit_config: Option<&Path>) -> Result<()> {
+    let path = config::resolve_path(explicit_config)?;
+    let created = ensure_config_exists(&path)?;
+    if created {
+        eprintln!("wrote default config to {}", path.display());
+    }
+    println!("{}", path.display());
+    Ok(())
+}
+
+fn edit(explicit_config: Option<&Path>) -> Result<()> {
+    let path = config::resolve_path(explicit_config)?;
+    let created = ensure_config_exists(&path)?;
+    if created {
+        eprintln!("wrote default config to {}", path.display());
+    }
+
+    let editor = pick_editor();
+    let mut parts = editor.split_whitespace();
+    let cmd = parts
+        .next()
+        .ok_or_else(|| anyhow!("no editor configured; set $EDITOR or $VISUAL"))?;
+    let extra: Vec<&str> = parts.collect();
+    let status = StdCommand::new(cmd)
+        .args(&extra)
+        .arg(&path)
+        .status()
+        .with_context(|| format!("failed to spawn editor `{editor}` for {}", path.display()))?;
+    if !status.success() {
+        bail!("editor `{editor}` exited with status {status}");
+    }
+    Ok(())
+}
+
+fn show(explicit_config: Option<&Path>, rendered: bool) -> Result<()> {
+    let path = config::resolve_path(explicit_config)?;
+    let text = if path.exists() {
+        std::fs::read_to_string(&path)
+            .with_context(|| format!("failed to read config file: {}", path.display()))?
+    } else {
+        config::DEFAULT_CONFIG_TOML.to_string()
+    };
+
+    let out = if rendered {
+        config::prerender(&text)?
+    } else {
+        text
+    };
+
+    if out.ends_with('\n') {
+        print!("{out}");
+    } else {
+        println!("{out}");
+    }
+    Ok(())
+}
+
+/// Write the embedded default config to `path` if the file doesn't exist yet.
+/// Returns `true` when a new file was created, `false` when one already existed.
+///
+/// Creates parent directories as needed. Never overwrites an existing file —
+/// the user's edits stay intact even if the embedded default has drifted.
+pub fn ensure_config_exists(path: &Path) -> Result<bool> {
+    if path.exists() {
+        return Ok(false);
+    }
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!("failed to create config directory: {}", parent.display())
+            })?;
+        }
+    }
+    std::fs::write(path, config::DEFAULT_CONFIG_TOML)
+        .with_context(|| format!("failed to write default config to: {}", path.display()))?;
+    Ok(true)
+}
+
+/// Pick the editor command per the `$VISUAL` → `$EDITOR` → platform-default
+/// chain. Empty / whitespace-only env values are treated as unset so the
+/// fallback chain keeps going.
+pub fn pick_editor() -> String {
+    for key in ["VISUAL", "EDITOR"] {
+        if let Ok(v) = std::env::var(key) {
+            if !v.trim().is_empty() {
+                return v;
+            }
+        }
+    }
+    if cfg!(windows) {
+        "notepad".to_string()
+    } else {
+        "vi".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    fn temp_dir() -> PathBuf {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let pid = std::process::id();
+        let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let d = std::env::temp_dir().join(format!("todoke-config-test-{stamp}-{pid}-{seq}"));
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    #[test]
+    fn ensure_config_exists_writes_default_when_missing() {
+        let dir = temp_dir();
+        let path = dir.join("nested").join("todoke.toml");
+        assert!(!path.exists());
+
+        let created = ensure_config_exists(&path).unwrap();
+
+        assert!(created);
+        assert!(path.exists());
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(written, config::DEFAULT_CONFIG_TOML);
+    }
+
+    #[test]
+    fn ensure_config_exists_does_not_overwrite_existing() {
+        let dir = temp_dir();
+        let path = dir.join("todoke.toml");
+        std::fs::write(&path, "# user-edited\n").unwrap();
+
+        let created = ensure_config_exists(&path).unwrap();
+
+        assert!(!created);
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(written, "# user-edited\n");
+    }
+
+    #[test]
+    fn ensure_config_exists_succeeds_when_path_has_no_parent_dir() {
+        // A bare filename (no parent component) shouldn't trip the
+        // create_dir_all guard — it should resolve to the cwd and just write.
+        let dir = temp_dir();
+        let path = dir.join("inline.toml");
+        let created = ensure_config_exists(&path).unwrap();
+        assert!(created);
+        assert!(path.exists());
     }
 }

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,3 +1,4 @@
+use std::io::Write;
 use std::path::Path;
 use std::process::Command as StdCommand;
 
@@ -57,13 +58,17 @@ fn edit(explicit_config: Option<&Path>) -> Result<()> {
     }
 
     let editor = pick_editor();
-    let mut parts = editor.split_whitespace();
-    let cmd = parts
-        .next()
+    // POSIX-style shell tokenization handles quoted paths with spaces
+    // (`"C:\Program Files\.../Code.exe" --wait`) and embedded args
+    // (`code --wait`, `nvim -p`) uniformly. Unquoted paths with spaces are
+    // unrepresentable in $EDITOR — same constraint git-core imposes.
+    let parts = shlex::split(&editor)
+        .ok_or_else(|| anyhow!("editor command has unbalanced quotes: {editor}"))?;
+    let (cmd, extra) = parts
+        .split_first()
         .ok_or_else(|| anyhow!("no editor configured; set $EDITOR or $VISUAL"))?;
-    let extra: Vec<&str> = parts.collect();
     let status = StdCommand::new(cmd)
-        .args(&extra)
+        .args(extra)
         .arg(&path)
         .status()
         .with_context(|| format!("failed to spawn editor `{editor}` for {}", path.display()))?;
@@ -101,10 +106,13 @@ fn show(explicit_config: Option<&Path>, rendered: bool) -> Result<()> {
 ///
 /// Creates parent directories as needed. Never overwrites an existing file —
 /// the user's edits stay intact even if the embedded default has drifted.
+///
+/// Atomicity: the write goes through `OpenOptions::create_new`, so the
+/// "exists check" and the "create" are a single OS-level operation. A
+/// concurrent process that creates the file between our check and our open
+/// loses to `AlreadyExists`, and we report `Ok(false)` instead of clobbering
+/// their content.
 pub fn ensure_config_exists(path: &Path) -> Result<bool> {
-    if path.exists() {
-        return Ok(false);
-    }
     if let Some(parent) = path.parent() {
         if !parent.as_os_str().is_empty() {
             std::fs::create_dir_all(parent).with_context(|| {
@@ -112,7 +120,20 @@ pub fn ensure_config_exists(path: &Path) -> Result<bool> {
             })?;
         }
     }
-    std::fs::write(path, config::DEFAULT_CONFIG_TOML)
+    let mut file = match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+    {
+        Ok(f) => f,
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => return Ok(false),
+        Err(e) => {
+            return Err(e).with_context(|| {
+                format!("failed to open config file for writing: {}", path.display())
+            });
+        }
+    };
+    file.write_all(config::DEFAULT_CONFIG_TOML.as_bytes())
         .with_context(|| format!("failed to write default config to: {}", path.display()))?;
     Ok(true)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -451,7 +451,7 @@ pub fn load_from_str(text: &str) -> Result<ResolvedConfig> {
 ///   as self-referential strings (`"{{ group }}"`) so those tokens pass
 ///   through pre-render unchanged and get rendered later with real values in
 ///   [`crate::dispatcher`].
-fn prerender(text: &str) -> Result<String> {
+pub fn prerender(text: &str) -> Result<String> {
     let vars = extract_vars(text);
 
     let mut tera = crate::template::new_engine();

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -31,11 +31,6 @@ pub async fn dispatch(cli: &Cli, files: &[PathBuf]) -> Result<()> {
 
     debug!(batches = plan.len(), "dispatch plan built");
 
-    if cli.dry_run {
-        print_plan(&plan);
-        return Ok(());
-    }
-
     run_plan(&cfg, plan).await
 }
 
@@ -43,7 +38,11 @@ pub async fn check(cli: &Cli, files: &[PathBuf]) -> Result<()> {
     let cfg = config::load(cli.config.as_deref())?;
     let raws = raw_argv(files);
     let inputs = load_inputs(cli, files)?;
-    let plan = plan_batches(cli, &cfg, &inputs, &raws)?;
+    let plan = if inputs.is_empty() {
+        plan_no_args(cli, &cfg)?
+    } else {
+        plan_batches(cli, &cfg, &inputs, &raws)?
+    };
     print_plan(&plan);
     Ok(())
 }
@@ -232,8 +231,7 @@ fn plan_no_args(cli: &Cli, cfg: &ResolvedConfig) -> Result<Vec<Batch>> {
     let (rule_idx, cap) = match hit {
         Some((i, c)) => (Some(i), c),
         None => {
-            let fallback =
-                (cli.editor.is_some() || cli.group.is_some()) && !cfg.raw.rules.is_empty();
+            let fallback = (cli.to.is_some() || cli.group.is_some()) && !cfg.raw.rules.is_empty();
             (fallback.then_some(0), CaptureMap::new())
         }
     };
@@ -604,10 +602,10 @@ fn resolve_rule<'a>(
     subject: &str,
     kind: InputKind,
 ) -> Result<Option<(usize, &'a Rule, CaptureMap)>> {
-    if cli.editor.is_some() || cli.group.is_some() {
+    if cli.to.is_some() || cli.group.is_some() {
         if cfg.raw.rules.is_empty() {
             bail!(
-                "--editor/--group requires at least one [[rules]] in config for mode/sync defaults"
+                "--todoke-to/--todoke-group requires at least one [[rules]] in config for mode/sync defaults"
             );
         }
         if let Some((idx, cap)) = first_match(cfg, subject, Some(kind)) {
@@ -643,8 +641,8 @@ fn resolve_target_name(
     tera: &mut tera::Tera,
     ctx: &tera::Context,
 ) -> Result<Option<String>> {
-    if let Some(e) = cli.editor.clone() {
-        return Ok(Some(e));
+    if let Some(t) = cli.to.clone() {
+        return Ok(Some(t));
     }
     match &rule.to {
         None => Ok(None),

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,9 +53,9 @@ async fn main() -> Result<()> {
         None => dispatcher::dispatch(&cli, &cli.files).await,
         Some(Command::List { alive_only }) => dispatcher::list(alive_only).await,
         Some(Command::Kill { group, all }) => dispatcher::kill(group.as_deref(), all).await,
-        Some(Command::Check { files }) => dispatcher::check(&cli, &files).await,
+        Some(Command::Check { inputs }) => dispatcher::check(&cli, &inputs).await,
         Some(Command::Doctor) => dispatcher::doctor(&cli).await,
-        Some(Command::Config(sub)) => cli::config::run(sub).await,
+        Some(Command::Config(sub)) => cli::config::run(sub, cli.config.as_deref()).await,
         Some(Command::Completion { shell }) => {
             clap_complete::generate(shell, &mut Cli::command(), "todoke", &mut std::io::stdout());
             Ok(())

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -83,11 +83,7 @@ fn no_args_uses_default_rule() {
         "#,
     );
 
-    let (ok, out, err) = run_with(&[
-        "--todoke-config",
-        &config.to_string_lossy(),
-        "--todoke-dry-run",
-    ]);
+    let (ok, out, err) = run_with(&["--todoke-config", &config.to_string_lossy(), "check"]);
     assert!(ok, "stderr: {err}");
     assert!(out.contains("to=echo"), "stdout: {out}");
     assert!(out.contains("rule=default"), "stdout: {out}");
@@ -179,7 +175,7 @@ fn gnu_posix_argument_syntax_parses_end_to_end() {
     // positional is that hyphen-shaped argv (`-f`, `+42`, `-sfoo`, …)
     // flow through as positionals without escape.
     let run_dry = |extra: &[&str]| -> String {
-        let mut args: Vec<&str> = vec!["--todoke-config", &cfg_str, "--todoke-dry-run"];
+        let mut args: Vec<&str> = vec!["--todoke-config", &cfg_str, "check"];
         args.extend_from_slice(extra);
         let (ok, out, err) = run_with(&args);
         assert!(ok, "failed for {extra:?}: stderr: {err}");
@@ -306,11 +302,7 @@ fn no_args_no_rules_errors() {
         "#,
     );
 
-    let (ok, _out, err) = run_with(&[
-        "--todoke-config",
-        &config.to_string_lossy(),
-        "--todoke-dry-run",
-    ]);
+    let (ok, _out, err) = run_with(&["--todoke-config", &config.to_string_lossy(), "check"]);
     assert!(!ok);
     assert!(err.contains("no rule matches empty-args"), "stderr: {err}");
 }
@@ -351,7 +343,7 @@ fn dry_run_plans_default_rule() {
     let (ok, out, err) = run_with(&[
         "--todoke-config",
         &config.to_string_lossy(),
-        "--todoke-dry-run",
+        "check",
         &file.to_string_lossy(),
     ]);
     assert!(ok, "stderr: {err}");
@@ -423,7 +415,7 @@ fn invalid_config_reports_error() {
     let (ok, _out, err) = run_with(&[
         "--todoke-config",
         &config.to_string_lossy(),
-        "--todoke-dry-run",
+        "check",
         &file.to_string_lossy(),
     ]);
     assert!(!ok);
@@ -448,9 +440,172 @@ fn unknown_to_reference_reports_error() {
     let (ok, _out, err) = run_with(&[
         "--todoke-config",
         &config.to_string_lossy(),
-        "--todoke-dry-run",
+        "check",
         &file.to_string_lossy(),
     ]);
     assert!(!ok);
     assert!(err.contains("unknown todoke target"), "stderr: {err}");
+}
+
+// --- `config` subcommand ---
+
+#[test]
+fn config_path_prints_explicit_override() {
+    let dir = temp_dir();
+    let config = dir.join("custom.toml");
+    let (ok, out, err) = run_with(&[
+        "--todoke-config",
+        &config.to_string_lossy(),
+        "config",
+        "path",
+    ]);
+    assert!(ok, "stderr: {err}");
+    assert!(out.trim_end().ends_with("custom.toml"), "stdout: {out}");
+}
+
+#[test]
+fn config_show_prints_embedded_default_when_no_file() {
+    let dir = temp_dir();
+    let config = dir.join("missing.toml");
+    let (ok, out, err) = run_with(&[
+        "--todoke-config",
+        &config.to_string_lossy(),
+        "config",
+        "show",
+    ]);
+    assert!(ok, "stderr: {err}");
+    // sanity-check anchors from the bundled default.toml
+    assert!(out.contains("[todoke.nvim]"), "stdout: {out}");
+    assert!(out.contains("editor-callback"), "stdout: {out}");
+}
+
+#[test]
+fn config_show_prints_user_file_contents() {
+    let dir = temp_dir();
+    let config = dir.join("todoke.toml");
+    let body = "# my custom config\n[todoke.code]\ncommand = \"code\"\n";
+    write_file(&config, body);
+    let (ok, out, err) = run_with(&[
+        "--todoke-config",
+        &config.to_string_lossy(),
+        "config",
+        "show",
+    ]);
+    assert!(ok, "stderr: {err}");
+    assert!(out.contains("# my custom config"), "stdout: {out}");
+    assert!(out.contains("[todoke.code]"), "stdout: {out}");
+}
+
+#[test]
+fn config_show_rendered_runs_tera() {
+    let dir = temp_dir();
+    let config = dir.join("todoke.toml");
+    write_file(
+        &config,
+        r#"
+            [vars]
+            gui = "neovide"
+
+            [todoke.gui]
+            command = "{{ vars.gui }}"
+
+            [[rules]]
+            match = ".*"
+            to = "gui"
+        "#,
+    );
+    let (ok, out, err) = run_with(&[
+        "--todoke-config",
+        &config.to_string_lossy(),
+        "config",
+        "show",
+        "--rendered",
+    ]);
+    assert!(ok, "stderr: {err}");
+    assert!(
+        out.contains("command = \"neovide\""),
+        "expected rendered Tera output, got: {out}"
+    );
+    // The pre-rendered form must not survive --rendered.
+    assert!(
+        !out.contains("{{ vars.gui }}"),
+        "stdout still has raw Tera tag: {out}"
+    );
+}
+
+#[test]
+fn config_init_writes_default_when_missing() {
+    let dir = temp_dir();
+    let config = dir.join("subdir").join("todoke.toml");
+    assert!(!config.exists());
+
+    let (ok, out, err) = run_with(&[
+        "--todoke-config",
+        &config.to_string_lossy(),
+        "config",
+        "init",
+    ]);
+    assert!(ok, "stderr: {err}");
+    assert!(config.exists(), "config file should have been created");
+    let written = std::fs::read_to_string(&config).unwrap();
+    assert!(written.contains("[todoke.nvim]"), "wrote: {written}");
+    assert!(out.contains("todoke.toml"), "stdout: {out}");
+    assert!(
+        err.contains("wrote default config"),
+        "stderr should announce the write: {err}"
+    );
+}
+
+#[test]
+fn config_init_is_idempotent() {
+    let dir = temp_dir();
+    let config = dir.join("todoke.toml");
+    write_file(&config, "# preserved by user\n");
+
+    let (ok, _out, err) = run_with(&[
+        "--todoke-config",
+        &config.to_string_lossy(),
+        "config",
+        "init",
+    ]);
+    assert!(ok, "stderr: {err}");
+    let after = std::fs::read_to_string(&config).unwrap();
+    assert_eq!(after, "# preserved by user\n");
+    assert!(
+        !err.contains("wrote default config"),
+        "should not announce a write when the file already exists: {err}"
+    );
+}
+
+// --- `doctor` subcommand ---
+
+#[test]
+fn doctor_succeeds_for_user_file() {
+    let dir = temp_dir();
+    let config = dir.join("todoke.toml");
+    write_file(
+        &config,
+        r#"
+            [todoke.echo]
+            command = "echo"
+
+            [[rules]]
+            name = "default"
+            match = ".*"
+            to = "echo"
+        "#,
+    );
+    let (ok, out, err) = run_with(&["--todoke-config", &config.to_string_lossy(), "doctor"]);
+    assert!(ok, "stderr: {err}");
+    assert!(out.contains("no issues"), "stdout: {out}");
+}
+
+#[test]
+fn doctor_fails_for_broken_toml() {
+    let dir = temp_dir();
+    let config = dir.join("bad.toml");
+    write_file(&config, "this is not valid toml [[[");
+    let (ok, _out, err) = run_with(&["--todoke-config", &config.to_string_lossy(), "doctor"]);
+    assert!(!ok);
+    assert!(err.contains("failed to parse TOML"), "stderr: {err}");
 }


### PR DESCRIPTION
## Summary

The CLI had grown several pairs of overlapping commands. v2 collapses
those onto a single canonical entry per concern and renames a couple
of flags to match the underlying vocabulary. Each removed item was a
strict duplicate of an existing one; each rename addresses a small
terminology mismatch with the TOML schema.

## Changes

### Removed
- `--todoke-dry-run` — duplicates `check`. `check` now accepts zero
  inputs (same `plan_no_args` path) so it fully replaces the flag.
- `config validate` — strict subset of `doctor`. `doctor` already
  parses the config and additionally reports unreachable rules,
  missing catch-all, duplicate rule names.
- `config edit --no-edit` — the flag name was self-contradictory.
  Split into `config init` (idempotent write, no editor) and
  `config edit` (which internally ensures the file exists, then
  spawns ``$EDITOR``).

### Renamed
- `--todoke-editor` → `--todoke-to`. Targets aren't always editors
  (browsers, scripts, …) and the TOML field is `to = "..."`.
- `check <FILES>` → `check <INPUTS>`. URLs / raw strings dispatch
  through `check` too.
- `config show --resolved` → `--rendered`. Avoids overload with the
  internal `ResolvedConfig` type (regex-compiled + validated), which
  is a different concept from "Tera-rendered TOML text".

### Added
- `config init` — idempotent "ensure the config file exists" command.
  Useful for setup scripts and dotfiles bootstrap. Stays silent when
  the file already exists, announces the write on first run.

### Behavior preserved
- The bundled default config still backs the no-file case (`config::load`
  path unchanged).
- `check` mirrors the top-level positional shape (`trailing_var_arg`
  + `allow_hyphen_values`), so `check +42 foo.txt` works without a
  `--` separator.

## Migration

| before | after |
| --- | --- |
| `todoke --todoke-dry-run X` | `todoke check X` |
| `todoke --todoke-editor T X` | `todoke --todoke-to T X` |
| `todoke config validate` | `todoke doctor` |
| `todoke config edit --no-edit` | `todoke config init` |
| `todoke config show --resolved` | `todoke config show --rendered` |

## Caveat

Removed flags don't produce "unknown flag" errors. The top-level
positional has `allow_hyphen_values = true` so unknown hyphen-shaped
argv flow into the input list and surface as a passthrough warning
from the neovim backend. Old scripts using `--todoke-dry-run` will
see weird routing rather than a clean diagnostic — release notes
should call this out.

## Test plan

- [x] `cargo make check` (fmt + clippy + 82 tests + lock-check) green
- [x] Smoke test `config path / init / edit / show / show --rendered`
- [x] Smoke test `check` with zero inputs and with `+42` flag forms
- [x] Verified `--help` surface no longer mentions removed flags
- [ ] Wait for Gemini Code Assist + CodeRabbit review
- [ ] Owner approval before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)