### PR TITLE
feat: out-of-the-box $EDITOR support for gemini-cli & claude-code

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,18 +34,29 @@ jobs:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --release --target ${{ matrix.target }}
+      # `todoke-vim` is a byte-for-byte copy of `todoke`, shipped as an
+      # alias so that `EDITOR=todoke-vim` (or `VISUAL=todoke-vim`) is
+      # detected as a terminal editor by callers that classify by name
+      # substring — most notably gemini-cli, which only treats names
+      # containing vi/vim/nvim/emacs/hx/nano as terminal editors and
+      # otherwise spawns async, leaving its TUI re-rendering over the
+      # editor. todoke ignores argv[0] so a plain copy is enough.
       - name: package (unix)
         if: runner.os != 'Windows'
         run: |
           mkdir -p dist
+          pkg=target/${{ matrix.target }}/release
+          cp "$pkg/todoke" "$pkg/todoke-vim"
           tar czf dist/todoke-${{ matrix.target }}.tar.gz \
-            -C target/${{ matrix.target }}/release todoke
+            -C "$pkg" todoke todoke-vim
       - name: package (windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force dist
-          Compress-Archive -Path target/${{ matrix.target }}/release/todoke.exe `
+          $pkg = "target/${{ matrix.target }}/release"
+          Copy-Item "$pkg/todoke.exe" "$pkg/todoke-vim.exe"
+          Compress-Archive -Path "$pkg/todoke.exe","$pkg/todoke-vim.exe" `
             -DestinationPath dist/todoke-${{ matrix.target }}.zip
       - uses: actions/upload-artifact@v7
         with:

--- a/README.md
+++ b/README.md
@@ -419,6 +419,49 @@ paths like `newfile.txt` or `/tmp/new.md`. So `todoke Makefile` and
 — rules match against the absolute path and the editor creates the
 file on write.
 
+#### Gemini CLI: use the `todoke-vim` alias
+
+Google's [gemini-cli][gemini-cli] picks the spawn strategy for `$EDITOR`
+by substring-matching the executable name against
+`vi`/`vim`/`nvim`/`emacs`/`hx`/`nano`. Anything else (including
+`todoke`) is treated as non-terminal: gemini-cli spawns it
+asynchronously and keeps its own Ink TUI re-rendering on top, so
+the editor never gets a clean screen and the terminal looks frozen.
+
+Workaround: invoke todoke under a name that contains one of those
+substrings. The release artifacts ship `todoke-vim` next to `todoke`
+for exactly this — point gemini-cli at the alias:
+
+```sh
+# Linux / macOS
+export VISUAL=todoke-vim   # gemini-cli prefers VISUAL over EDITOR
+
+# Windows (PowerShell)
+$env:VISUAL = "todoke-vim"
+```
+
+`cargo install todoke` only installs `todoke`, so cargo users need to
+create the alias themselves:
+
+```sh
+# Linux / macOS
+ln -sf "$(command -v todoke)" ~/.cargo/bin/todoke-vim
+
+# Windows (PowerShell)
+Copy-Item (Get-Command todoke).Source "$env:USERPROFILE\.cargo\bin\todoke-vim.exe"
+```
+
+todoke ignores `argv[0]`, so a copy or symlink behaves identically to
+the canonical binary. Setting `VISUAL` (rather than overriding
+`EDITOR`) keeps `EDITOR=todoke` working for every other caller.
+Gemini-cli also injects `-i NONE` ahead of the file path when it
+recognises a vim-family editor — the bundled default config has a
+`nvim-value-flag` passthrough rule (`-i`/`-c`/`-S`/… plus their
+spaced value) so the pair reaches nvim intact, and a matching
+`editor-callback` entry for `gemini-edit-*/buffer.txt` so the dispatch
+runs `mode = "new", sync = true` and gemini-cli reads the edited
+result.
+
 ### As OS default program (Windows)
 
 Right-click a `.txt` → Open with → Choose another app → Browse → point at
@@ -583,3 +626,4 @@ Planned:
 [MIT](./LICENSE) — © 2026 yukimemi.
 
 [tera]: https://keats.github.io/tera/docs/#built-ins
+[gemini-cli]: https://github.com/google-gemini/gemini-cli

--- a/assets/default.toml
+++ b/assets/default.toml
@@ -13,14 +13,52 @@ kind = "neovim"
 command = "nvim"
 listen = '{% if is_windows() %}\\.\pipe\nvim-todoke-{{ group }}{% else %}/tmp/nvim-todoke-{{ group }}.sock{% endif %}'
 
-# git commit, rebase todo, merge messages etc. — always a fresh nvim, block
-# until it exits so callers like `git commit` see the result.
+# git commit / rebase, AI-tool prompt temp files etc. — always a fresh
+# nvim, block until it exits so the calling tool (git, gemini-cli,
+# claude-code, …) reads the edited file. Gemini CLI prompt files only
+# match when todoke is invoked as a `vim`-named alias (see README); see
+# the README for the rationale.
 [[rules]]
 name = "editor-callback"
-match = '(?i)/(COMMIT_EDITMSG|MERGE_MSG|TAG_EDITMSG|EDIT_DESCRIPTION|git-rebase-todo|\.gitmessage|NOTES_EDITMSG|svn-commit\.tmp)$'
+match = [
+  # git / svn / hg commit + rebase + tag edit messages
+  '(?i)/(COMMIT_EDITMSG|MERGE_MSG|TAG_EDITMSG|EDIT_DESCRIPTION|git-rebase-todo|\.gitmessage|NOTES_EDITMSG|svn-commit\.tmp)$',
+  # Claude Code prompt temp files
+  '(?i)/claude-prompt-.*$',
+  # Gemini CLI prompt temp files (mkdtemp `gemini-edit-XXXX/buffer.txt`)
+  '(?i)/gemini-edit.*$',
+]
 to = "nvim"
 mode = "new"
 sync = true
+
+# Neovim-family flags that take a spaced value on the next argv
+# (`-c :set ft=md`, `-S session.vim`, `-i NONE`, `--listen /tmp/sock`, …).
+# `consumes = 1` keeps the flag and its value together so they reach nvim
+# intact. Must come before `any-flag` so the more-specific value-taking
+# pattern wins; otherwise the trailing value would be classified as a
+# separate input.
+#
+# `-i NONE` in particular is what Gemini CLI injects when it recognises
+# the editor as vim-family — see README.
+#
+# Note: this binds `-i` (and other letters above) as value-taking by
+# default. If you use $EDITOR=todoke with a tool that calls `-i` with
+# different semantics, drop a `~/.config/todoke/todoke.toml` and tune
+# this rule to taste.
+[[rules]]
+name = "nvim-value-flag"
+match = '^(?:-[cSuUitwW]|--cmd|--startuptime|--listen|--server)$'
+passthrough = true
+consumes = 1
+
+# Catch-all for ex-editor-style argv: `+42`, lone `-`/`+` flags todoke
+# wouldn't otherwise know what to do with. `to` is omitted so the flag
+# rides along with whichever input rule built a batch in the same group.
+[[rules]]
+name = "any-flag"
+match = '^[-+]'
+passthrough = true
 
 # Everything else: reuse a single long-running nvim called "default".
 [[rules]]

--- a/assets/default.toml
+++ b/assets/default.toml
@@ -15,18 +15,22 @@ listen = '{% if is_windows() %}\\.\pipe\nvim-todoke-{{ group }}{% else %}/tmp/nv
 
 # git commit / rebase, AI-tool prompt temp files etc. — always a fresh
 # nvim, block until it exits so the calling tool (git, gemini-cli,
-# claude-code, …) reads the edited file. Gemini CLI prompt files only
-# match when todoke is invoked as a `vim`-named alias (see README); see
-# the README for the rationale.
+# claude-code, …) reads the edited file. Gemini CLI only spawns the
+# editor for prompt files when it recognises the binary as a vim-family
+# name, so the gemini-edit branch only fires when todoke is invoked under
+# the `todoke-vim` alias — see README. The patterns below pin the
+# `claude-prompt-` / `gemini-edit-` shape to the basename so a project
+# directory named `gemini-edit-clone/` doesn't accidentally route as a
+# prompt file.
 [[rules]]
 name = "editor-callback"
 match = [
   # git / svn / hg commit + rebase + tag edit messages
   '(?i)/(COMMIT_EDITMSG|MERGE_MSG|TAG_EDITMSG|EDIT_DESCRIPTION|git-rebase-todo|\.gitmessage|NOTES_EDITMSG|svn-commit\.tmp)$',
-  # Claude Code prompt temp files
-  '(?i)/claude-prompt-.*$',
+  # Claude Code prompt temp files (basename starts with claude-prompt-)
+  '(?i)/claude-prompt-[^/]+$',
   # Gemini CLI prompt temp files (mkdtemp `gemini-edit-XXXX/buffer.txt`)
-  '(?i)/gemini-edit.*$',
+  '(?i)/gemini-edit-[^/]+/buffer\.txt$',
 ]
 to = "nvim"
 mode = "new"

--- a/src/config.rs
+++ b/src/config.rs
@@ -554,11 +554,23 @@ mod tests {
     fn parses_default_config() {
         let cfg = load_from_str(DEFAULT_CONFIG_TOML).expect("default config must parse");
         assert!(cfg.raw.todoke.contains_key("nvim"));
-        assert_eq!(cfg.raw.rules.len(), 2);
-        assert_eq!(cfg.raw.rules[0].name.as_deref(), Some("editor-callback"));
-        assert_eq!(cfg.raw.rules[1].name.as_deref(), Some("default"));
+        let names: Vec<&str> = cfg
+            .raw
+            .rules
+            .iter()
+            .map(|r| r.name.as_deref().unwrap_or(""))
+            .collect();
+        assert_eq!(
+            names,
+            vec!["editor-callback", "nvim-value-flag", "any-flag", "default"],
+        );
+        // Only editor-callback blocks; passthrough/default rules don't.
         assert!(cfg.raw.rules[0].sync);
-        assert!(!cfg.raw.rules[1].sync);
+        assert!(!cfg.raw.rules[3].sync);
+        // Passthrough rules are passthrough; nvim-value-flag eats its next argv.
+        assert!(cfg.raw.rules[1].passthrough);
+        assert_eq!(cfg.raw.rules[1].consumes, 1);
+        assert!(cfg.raw.rules[2].passthrough);
     }
 
     #[test]

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -343,8 +343,50 @@ mod tests {
         );
 
         let idx = first_match_idx(&cfg, "/home/x/notes/idea.md");
-        assert_eq!(idx, Some(1));
-        assert_eq!(cfg.rule(idx.unwrap()).name.as_deref(), Some("default"));
+        assert_eq!(
+            cfg.rule(idx.expect("default rule must match plain files"))
+                .name
+                .as_deref(),
+            Some("default"),
+        );
+    }
+
+    #[test]
+    fn default_config_matches_ai_tool_prompt_paths() {
+        let cfg = load_from_str(crate::config::DEFAULT_CONFIG_TOML).unwrap();
+        for path in [
+            // Claude Code prompt
+            "/tmp/claude-prompt-abc123.txt",
+            // Gemini CLI prompt (mkdtemp dir + buffer.txt)
+            "/tmp/gemini-edit-abc123/buffer.txt",
+        ] {
+            let idx =
+                first_match_idx(&cfg, path).unwrap_or_else(|| panic!("no rule matched {path}"));
+            assert_eq!(
+                cfg.rule(idx).name.as_deref(),
+                Some("editor-callback"),
+                "expected editor-callback to match {path}",
+            );
+        }
+    }
+
+    #[test]
+    fn default_config_passthrough_catches_nvim_value_flag() {
+        let cfg = load_from_str(crate::config::DEFAULT_CONFIG_TOML).unwrap();
+        // -i is what gemini-cli injects in front of the file path; the
+        // rule's `consumes = 1` tells the dispatcher to also eat `NONE`.
+        let (idx, _cap) =
+            first_passthrough_match(&cfg, "-i").expect("nvim-value-flag should match `-i`");
+        assert_eq!(cfg.rule(idx).name.as_deref(), Some("nvim-value-flag"));
+        assert_eq!(cfg.rule(idx).consumes, 1);
+    }
+
+    #[test]
+    fn default_config_passthrough_catches_any_flag() {
+        let cfg = load_from_str(crate::config::DEFAULT_CONFIG_TOML).unwrap();
+        let (idx, _cap) =
+            first_passthrough_match(&cfg, "+42").expect("any-flag should match `+42`");
+        assert_eq!(cfg.rule(idx).name.as_deref(), Some("any-flag"));
     }
 
     #[test]

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -371,6 +371,31 @@ mod tests {
     }
 
     #[test]
+    fn default_config_does_not_misroute_project_dirs_named_like_prompts() {
+        // Files inside project directories whose name starts with
+        // `claude-prompt-` / `gemini-edit-` must NOT route through
+        // editor-callback (mode=new, sync=true). They should fall through
+        // to the catch-all `default` rule.
+        let cfg = load_from_str(crate::config::DEFAULT_CONFIG_TOML).unwrap();
+        for path in [
+            "/home/me/projects/claude-prompt-clone/src/main.rs",
+            "/home/me/projects/gemini-edit-clone/notes.md",
+            // Gemini CLI's basename must be exactly `buffer.txt` — a
+            // file with a different name inside such a dir is a project
+            // file, not a prompt artifact.
+            "/tmp/gemini-edit-abc123/other.txt",
+        ] {
+            let idx =
+                first_match_idx(&cfg, path).unwrap_or_else(|| panic!("no rule matched {path}"));
+            assert_eq!(
+                cfg.rule(idx).name.as_deref(),
+                Some("default"),
+                "{path} should fall through to default, not editor-callback",
+            );
+        }
+    }
+
+    #[test]
     fn default_config_passthrough_catches_nvim_value_flag() {
         let cfg = load_from_str(crate::config::DEFAULT_CONFIG_TOML).unwrap();
         // -i is what gemini-cli injects in front of the file path; the


### PR DESCRIPTION
## Summary

- Ship `todoke-vim` (byte-for-byte copy of `todoke`) in release tarballs / zips so that gemini-cli classifies it as a terminal editor (it substring-matches `vi`/`vim`/`nvim`/...). With `EDITOR=todoke`, gemini-cli falls into the async-spawn path and keeps re-rendering its Ink TUI on top of the editor — terminal looks frozen.
- Strengthen the embedded default config so a fresh `cargo install todoke` Just Works out of the box for both gemini-cli and claude-code:
  - `editor-callback` (mode=new, sync=true) now also matches `claude-prompt-*` and `gemini-edit-*/buffer.txt`.
  - new `nvim-value-flag` passthrough (`-c`/`-S`/`-i`/... + `consumes = 1`) so gemini-cli's injected `-i NONE` reaches nvim as a flag-value pair instead of being opened as files.
  - new `any-flag` passthrough catches `+42`-style trailing flags.
- README documents the gemini-cli quirk, the alias mechanism, and the cargo-install workaround (ln / Copy-Item).

### Trade-off

The `nvim-value-flag` rule binds `-i` (and the other letters in the regex) as value-taking by default. Users who want different `-i` semantics need a personal `~/.config/todoke/todoke.toml`. The default config comment calls this out.

## Test plan

- [x] `cargo make check` — fmt + clippy + 66 unit + 19 integration + locked check, all green.
- [x] Tests added: `default_config_matches_ai_tool_prompt_paths`, `default_config_passthrough_catches_nvim_value_flag`, `default_config_passthrough_catches_any_flag`. Existing `parses_default_config` and `default_config_matches_commit_editmsg` updated for the new rule shape.
- [x] Manually verified end-to-end on Windows: `cp todoke.exe todoke-vim.exe; $env:EDITOR = "todoke-vim"; gemini` opens nvim cleanly and the prompt round-trips back to gemini-cli on `:wq`.
- [ ] (CI) verify the release workflow still produces a usable archive — packaging change is straightforward (extra `cp` / `Copy-Item`) but the workflow is gated on a tag push so it'll only run when v2.1.0 (or whatever) lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `todoke-vim` binary alias included in all release distributions for improved Gemini CLI editor-spawn compatibility.

* **Documentation**
  * New comprehensive guide covering `todoke-vim` alias creation methods (cargo/releases), platform-specific instructions (Linux/macOS/Windows), and `$VISUAL` environment variable configuration.

* **Improvements**
  * Enhanced configuration routing to handle editor command-line flags and AI-generated prompt files correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->