### PR TITLE
docs(README): drop "NOT IMPLEMENTED YET" markers for list/kill, mark v2.2.0 shipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,8 +563,8 @@ and rule sections, and all other stock [Tera features][tera].
 todoke [INPUTS]...           # dispatch inputs per rules (default action)
 todoke check [INPUTS]...     # dry-run: show the dispatch plan without executing
 todoke doctor                # lint the config for common footguns
-todoke list                  # list alive handler instances (NOT IMPLEMENTED YET)
-todoke kill <group> | --all  # terminate instances (NOT IMPLEMENTED YET)
+todoke list [--alive-only]              # list discovered editor instances (alive + stale)
+todoke kill <group> | --all [--force]   # quit instances via :qall!; --force escalates to OS kill (SIGKILL / TerminateProcess) when wedged
 todoke config path           # print the resolved config file path
 todoke config init           # write the embedded default config if missing (idempotent)
 todoke config edit           # open the config in $EDITOR (writes the default first if missing)
@@ -610,10 +610,17 @@ Shipped (v2.0.0):
 - full `config` subcommand surface — `path` / `init` / `edit` / `show`
 - breaking CLI cleanup vs. the v1.x line — see the v2.0.0 release notes
 
+Shipped (v2.2.0):
+
+- `list` / `kill` — discover running editor instances by reverse-engineering
+  each `[todoke.<name>]`'s `listen` template (Unix socket / Windows named
+  pipe), then RPC-ping each candidate to mark `alive` vs `stale`.
+  `kill <group>|--all` quits matching instances via `:qall!`, unlinks
+  stale Unix sockets left by crashed nvims, and with `--force` escalates
+  to `SIGKILL` / `TerminateProcess` for wedged processes.
+
 Planned:
 
-- `list` / `kill` — currently stubbed (`bail!("not implemented yet")`);
-  list alive nvim instances and terminate them by group
 - neovim `remote + sync` via `nvim_buf_attach` — block on a reused
   nvim until the user closes the buffer (currently only fresh-spawn
   nvim supports `sync = true`)

--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ todoke [INPUTS]...           # dispatch inputs per rules (default action)
 todoke check [INPUTS]...     # dry-run: show the dispatch plan without executing
 todoke doctor                # lint the config for common footguns
 todoke list [--alive-only]              # list discovered editor instances (alive + stale)
-todoke kill <group> | --all [--force]   # quit instances via :qall!; --force escalates to OS kill (SIGKILL / TerminateProcess) when wedged
+todoke kill <group>|--all [--force]     # quit instances via :qall!; --force escalates to OS kill (SIGKILL / TerminateProcess) when wedged
 todoke config path           # print the resolved config file path
 todoke config init           # write the embedded default config if missing (idempotent)
 todoke config edit           # open the config in $EDITOR (writes the default first if missing)


### PR DESCRIPTION
## Summary

The README has been lagging behind v2.2.0 — the CLI reference table still labelled `list` / `kill` as `(NOT IMPLEMENTED YET)`, and the Roadmap kept them under Planned. Update both:

- **CLI reference**: real signatures including `--alive-only` on `list` and `--force` on `kill`.
- **Roadmap**: new `Shipped (v2.2.0)` section describing the discovery + `:qall!` / `SIGKILL` / `TerminateProcess` flow. The Planned bullet for list/kill is removed.

Pure docs change — no code touched. `cargo make check` is green via the pre-push hook (sanity check, even though the change wouldn't break tests).

## Test plan

- [x] `cargo make check` (pre-push hook) — green.
- [ ] Visual review: README CLI table reads accurately, Roadmap structure stays consistent with the existing v2.0.0 Shipped block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI reference with finalized command options
  * `todoke list` now supports `--alive-only` flag to filter active editor instances
  * `todoke kill` now supports `--force` flag for forceful process termination
  * Editor instances are categorized as alive or stale

<!-- end of auto-generated comment: release notes by coderabbit.ai -->