### PR TITLE
chore: bootstrap kata-managed templates from pj-presets:rust-cli

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{rs,toml}]
+indent_size = 4
+
+[Makefile,*.mk]
+indent_style = tab

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,11 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  # Cargo binary name derived from the GitHub repo so this template
+  # works unchanged for any yukimemi/* CLI without per-PJ patching.
+  # If your `[[bin]] name` in Cargo.toml differs from the repo name,
+  # override this on the spot.
+  BIN_NAME: ${{ github.event.repository.name }}
 
 jobs:
   build:
@@ -34,33 +39,23 @@ jobs:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --release --target ${{ matrix.target }}
-      # `todoke-vim` is a byte-for-byte copy of `todoke`, shipped as an
-      # alias so that `EDITOR=todoke-vim` (or `VISUAL=todoke-vim`) is
-      # detected as a terminal editor by callers that classify by name
-      # substring — most notably gemini-cli, which only treats names
-      # containing vi/vim/nvim/emacs/hx/nano as terminal editors and
-      # otherwise spawns async, leaving its TUI re-rendering over the
-      # editor. todoke ignores argv[0] so a plain copy is enough.
       - name: package (unix)
         if: runner.os != 'Windows'
         run: |
           mkdir -p dist
           pkg=target/${{ matrix.target }}/release
-          cp "$pkg/todoke" "$pkg/todoke-vim"
-          tar czf dist/todoke-${{ matrix.target }}.tar.gz \
-            -C "$pkg" todoke todoke-vim
+          tar czf "dist/${BIN_NAME}-${{ matrix.target }}.tar.gz" -C "$pkg" "${BIN_NAME}"
       - name: package (windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force dist
           $pkg = "target/${{ matrix.target }}/release"
-          Copy-Item "$pkg/todoke.exe" "$pkg/todoke-vim.exe"
-          Compress-Archive -Path "$pkg/todoke.exe","$pkg/todoke-vim.exe" `
-            -DestinationPath dist/todoke-${{ matrix.target }}.zip
+          Compress-Archive -Path "$pkg/$env:BIN_NAME.exe" `
+            -DestinationPath "dist/$env:BIN_NAME-${{ matrix.target }}.zip"
       - uses: actions/upload-artifact@v7
         with:
-          name: todoke-${{ matrix.target }}
+          name: ${{ env.BIN_NAME }}-${{ matrix.target }}
           path: dist/*
 
   release:
@@ -86,6 +81,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      # --locked keeps the committed Cargo.lock so the publish verification
-      # step cannot fail the dirty-git-state check by rewriting the lock.
+      # --locked keeps the committed Cargo.lock so the publish
+      # verification step cannot fail the dirty-git-state check by
+      # rewriting the lock.
       - run: cargo publish --locked --token ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,12 @@
 
 # APM dependencies
 apm_modules/
+# kata:gitignore:base:begin
+# Editor / OS noise — kata-managed (yukimemi/pj-base).
+.idea/
+.vscode/
+*.swp
+*~
+.DS_Store
+Thumbs.db
+# kata:gitignore:base:end

--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,0 +1,58 @@
+preset = "github.com/yukimemi/pj-presets:rust-cli"
+applied_at = "2026-05-05T15:48:30.23603Z"
+
+[[templates]]
+source = "github.com/yukimemi/pj-base"
+rev = "c8c22d87d21225ce16543f7c9d0d417f4cf36b8d"
+version = "0.2.0"
+
+[[templates]]
+source = "github.com/yukimemi/pj-rust"
+rev = "3deb51c5fb667544a10c2bbcefc180290eb8db54"
+version = "0.2.0"
+
+[[templates]]
+source = "github.com/yukimemi/pj-rust-cli"
+rev = "048e9fecbe348a9f0507b4fe61d259810d6c704a"
+version = "0.2.0"
+
+[files.".editorconfig"]
+content_hash = "58657ee086523ff34b0b1aef4da8a50a7489d1219ed206ddd774794f493275bb"
+once_applied = true
+
+[files.".github/workflows/release.yml"]
+content_hash = "fd5c3f524d212d7d237b9f410d0d2a0378e2a434ddac1dadef38da1bcc46fb2b"
+once_applied = true
+
+[files.".gitignore"]
+content_hash = "733fc58cfdd43e5c91b522e71932bbd22c83b51700937fed382564bbe7262193"
+
+[files."AGENTS.md"]
+content_hash = "e4f146a1c66d11e6b6c707f52507b3e37da2fe52d8d7cf13f75edcf9ad5d3a7f"
+
+[files."CLAUDE.md"]
+content_hash = "a76b3af252969b8120128d7ce44f2b6cfdcf88c7420ee00675732f542d047529"
+
+[files."GEMINI.md"]
+content_hash = "3670f70a2f0be4013926bab6e878b90a42ad64c17899080aef4d193b246fa390"
+
+[files."Makefile.toml"]
+content_hash = "a472b7d29835466dfa5d9fe7dbceb69dd39736a5b05b1fbe5b2cd7726a63a025"
+
+[files."apm.yml"]
+content_hash = "b15c61f2542b99cbeccafe8808d0fbe1afd741edf2c2d72fe6d9281e12ddc08d"
+
+[files."clippy.toml"]
+content_hash = "89dbb3b4fd63c479f61f077d2383ab5c0998ea838f271ed57fd09281975deda0"
+
+[files."renovate.json"]
+content_hash = "2ad03ca1cca4789f4f4be3ff727b2aff2fe252bbf7a49e32f20d20d3731ca3f5"
+
+[files."renri.toml"]
+content_hash = "f4751570494ba62997cfb47e3abee2e707d3e01d924d1e8b940905a4e7c974f3"
+
+[files."rust-toolchain.toml"]
+content_hash = "9eac3c057320afbad00022718e0c14731122b4c3f28abd2dc702846244c39f66"
+
+[files."rustfmt.toml"]
+content_hash = "8a0bd07a7aaaf3e9fed5dd297b04a5f96c4a969d895375aa4e00247a95aa616c"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,273 @@
+# AGENTS.md
+
+Guidance for AI agents (Claude / Codex / Gemini) working in this
+repo. The yukimemi/* shared conventions live in the
+`<!-- kata:agents:* -->` blocks below, sourced from
+`yukimemi/pj-base` / `pj-rust` / `pj-rust-cli` via `kata apply` —
+see those for git workflow, PR review cycle, build/lint/test
+commands, release flow, and renri worktree usage.
+
+The sections above the marker blocks are todoke-specific and
+consumer-owned: edit them freely; `kata apply` won't touch them.
+
+## What todoke is
+
+A rule-driven file/URL/raw-string dispatcher, written in Rust. Takes
+positional args (`todoke <arg> <arg> ...`), classifies each as a
+`File` / `Url` / `Raw`, runs it against TOML-defined `[[rules]]`, and
+hands the match to the rule's `to = "<target>"` — either an `exec`
+backend (spawn a command) or a `neovim` backend (msgpack-RPC reuse of
+a running nvim).
+
+Name comes from 届け (todoke, "deliver"), successor to `edtr` / `hitori.vim`.
+
+## Source layout
+
+- `src/main.rs` — entry point, wires `clap` to `dispatcher::dispatch`.
+- `src/cli.rs` — clap `Cli` struct.
+- `src/input.rs` — `Input` enum (`File`/`Url`/`Raw`), auto-detect
+  (URL → existing file → custom-scheme → invalid-chars → File).
+- `src/config.rs` — TOML schema (`Config`, `Target`, `Rule`,
+  `InputTypes`), Tera pre-render, `ResolvedConfig` with compiled regexes.
+- `src/matcher.rs` — `first_match` / `first_joined_match` /
+  `first_passthrough_match`; path normalization.
+- `src/dispatcher.rs` — the orchestrator. `plan_batches` builds the
+  batches (joined phase → per-argv pass 2a → passthrough pass 2b);
+  `run_batch` dispatches a batch to its backend.
+- `src/backends/exec.rs`, `src/backends/neovim.rs` — the two backends.
+- `src/template.rs` — Tera engine + context builder.
+- `src/platform.rs` — `spawn_detached` shim (cmd /c start on Windows).
+- `src/style.rs` — TTY color helpers.
+- `tests/cli.rs` — integration tests, `cargo run` via
+  `env!("CARGO_BIN_EXE_todoke")`.
+
+## Key design decisions (don't rediscover)
+
+- **Auto-detect is file-first.** Anything that isn't a URL
+  (`scheme://`) or a custom-scheme id (`issue:42`) or a string with
+  path-invalid chars (`<>"|?*`, controls) classifies as `File`. Bare
+  `Makefile` / `HEAD` / `newfile.txt` all become `File` so editors can
+  open / create them. Rules that want `Raw` semantics must opt in with
+  `input_type = "raw"`.
+- **Rule matching runs in three phases.** Joined first (regex against
+  space-joined argv), then per-argv (where **passthrough rules are
+  tried before normal rules** for each argv, so `first_passthrough_match`
+  wins over `first_match` when both would hit), then a passthrough
+  attachment pass that merges passthrough hits into the existing
+  `(target, group)` batch — see `dispatcher.rs:plan_batches`.
+- **`joined` and `passthrough` are mutually exclusive.** Config
+  rejects rules that set both. There's an open issue (#22) for an
+  "extract" mode that would combine them, parked until a real config
+  needs it.
+- **`consumes` / `consumes_until` / `consumes_rest` are exclusive.**
+  At most one may be set per passthrough rule (setting two or more is
+  a compile error; setting none is fine — the rule then just
+  passthroughs the single matched argv).
+- **The TOML is pre-rendered in two passes.** The first pass is a
+  manual line-scan in `extract_vars` to populate `[vars]` into the
+  Tera context; the second pass is a single Tera render of the whole
+  file with that context. Dispatch-time tokens (`{{ file_path }}`,
+  `{{ group }}`, etc.) round-trip as self-referential strings so they
+  survive pre-render intact.
+- **`neovim` backend rejects non-file inputs.** URL / Raw inputs are
+  warned and skipped — that's why non-GitHub URL rules need an
+  `input_type = "url"` browser fallback.
+- **Neovim remote mode can't deliver passthrough flags.** The RPC
+  session is post-startup; a warn fires and the flags are dropped.
+  Passthrough only reaches nvim on spawn paths (`new`, or remote
+  fallback that spawns with `--listen`).
+
+## Testing policy
+
+Practice **TDD** (red-green-refactor):
+
+1. Write (or extend) a failing test in `src/<mod>.rs::tests` for unit
+   scope, or `tests/cli.rs` for end-to-end scope.
+2. Implement until green.
+3. Refactor with tests still green.
+
+Commits should show tests arriving alongside the behaviour that
+makes them pass — reviewers (and future you) read the test as the
+authoritative spec, not "write code then bolt on tests
+afterwards".
+
+(Generic `cargo make` invocations are documented in the kata
+`pj-rust` block below.)
+
+## Useful invocations
+
+```sh
+# Dry-run a dispatch (shows planned batches, doesn't spawn)
+cargo run --quiet -- --dry-run -- +42 foo.txt
+
+# Override config path for experiments
+TODOKE_CONFIG=/tmp/exp.toml cargo run --quiet -- --dry-run -- <args>
+
+# Config static analysis
+cargo run --quiet -- doctor
+
+# Show which rule matches each arg without dispatching
+cargo run --quiet -- check foo.txt https://example.com issue:42
+```
+
+## Version + changelog
+
+Version lives only in `Cargo.toml`. `cargo check` refreshes `Cargo.lock`
+after a bump. Commit titles follow `<type>: <summary> (vX.Y.Z)` (e.g.
+`feat: ... (v0.3.19)`) so the release surface is traceable from `git log`.
+
+<!-- kata:agents:base:begin -->
+## yukimemi/* shared conventions
+
+This file is the agent-agnostic source of truth (per the
+[agents.md](https://agents.md) convention). The matching
+`CLAUDE.md` and `GEMINI.md` files are thin shims that point back
+here so each tool's auto-load behaviour still finds something.
+**Edit AGENTS.md, not the shims.**
+
+### Git workflow
+
+- **No direct push to `main`.** Open a PR.
+  - Exception: trivial typo / whitespace / docs wording fixes.
+  - Exception: standalone version bumps.
+- Branch names: `feat/...`, `fix/...`, `chore/...`.
+- **PR titles + bodies in English. Commit messages in English.**
+- Tag-based releases: `git tag vX.Y.Z && git push origin vX.Y.Z`.
+
+### PR review cycle
+
+- Every PR runs reviews from **Gemini Code Assist** and
+  **CodeRabbit**. Wait for both bots to post, address their
+  comments (push fixes to the PR branch), and merge only after
+  feedback is resolved.
+- **Reply to reviewers after pushing a fix.** Reply on the
+  corresponding review thread with an **@-mention**
+  (`@gemini-code-assist` / `@coderabbitai`). Silent fixes are
+  invisible to reviewers and cost the audit trail.
+- A review thread is **settled** the moment the latest bot reply
+  is ack-only ("Thank you" / "Understood" / a re-review summary
+  with no new findings) or 30 minutes elapse with no actionable
+  comment.
+- **Merge gate**: review bots quiet AND owner explicit approval.
+- Bot-authored PRs (Renovate / Dependabot) skip the bot-review
+  gate; CI green + owner approval is enough.
+
+### Worktree workflow
+
+Use [`renri`](https://github.com/yukimemi/renri) for any
+commit-bound change. From the main checkout:
+
+```sh
+renri add <branch-name>            # create a worktree (jj-first)
+renri --vcs git add <branch-name>  # force a git worktree
+renri remove <branch-name>         # cleanup after merge
+renri prune                        # GC stale worktrees
+```
+
+Read-only inspection can stay on the main checkout.
+
+### kata-managed sections
+
+Several files in this repo are managed by `kata apply` from the
+[`yukimemi/pj-presets`](https://github.com/yukimemi/pj-presets)
+templates — the bytes between `<!-- kata:*:begin -->` and
+`<!-- kata:*:end -->` markers, plus the overwrite-always files
+listed in `.kata/applied.toml`. **Editing those bytes locally
+won't survive the next `kata apply`** — push the change to the
+upstream template repo (`yukimemi/pj-base` / `yukimemi/pj-rust` /
+…) instead. The marker scopes are layered:
+
+- `kata:agents:base:*` — language-agnostic conventions (this section).
+- `kata:agents:rust:*` — added when `pj-rust` applies.
+- `kata:agents:rust-cli:*` — added when `pj-rust-cli` applies.
+<!-- kata:agents:base:end -->
+<!-- kata:agents:rust:begin -->
+### Rust workflow
+
+This repo follows the yukimemi/* Rust toolchain conventions. The
+language-agnostic conventions block above (`kata:agents:base:*`)
+covers git workflow, PR review cycle, and worktree usage.
+
+### Build / lint / test
+
+```sh
+cargo make check                    # fmt --check + clippy + test + lock-check (the pre-push gate)
+cargo make setup                    # one-time hook install + apm install
+cargo build                         # debug build
+cargo build --release               # release build
+cargo test                          # tests; add -- --nocapture for stdout
+```
+
+`cargo make check` is what `.github/workflows/ci.yml` runs and what
+the local pre-push hook calls — anything that passes locally
+should pass on CI and vice versa. Don't paper over a failing
+clippy by sprinkling `#[allow(clippy::...)]`; fix the underlying
+issue or push back on the lint with reasoning.
+
+### Toolchain pin
+
+The Rust toolchain is pinned via `rust-toolchain.toml` and the
+project compiles with the `stable` channel. Don't introduce
+nightly-only features without a real reason; if you do, document
+the reason in the relevant module.
+
+### Lint / format policy
+
+`rustfmt.toml` and `clippy.toml` are kata-managed (sourced from
+`yukimemi/pj-rust`). Edits to those files in this repo won't
+survive the next `kata apply`; if a setting is wrong, push the
+fix to `yukimemi/pj-rust` so every yukimemi/* Rust project picks
+it up.
+
+### CI workflow
+
+`.github/workflows/ci.yml` is also kata-managed. The source lives
+in `yukimemi/pj-rust/.github/workflows/ci.yml.template` (the
+`.template` suffix keeps GitHub Actions from running the source
+itself in pj-rust); each Rust project receives the rendered
+`ci.yml` via `kata apply`. Action versions are bumped centrally
+by Renovate at `yukimemi/pj-rust` and propagate down on the next
+apply, so don't bump them locally — Renovate is configured
+(via the kata-distributed `renovate.json`) to ignore
+`.github/workflows/ci.yml` and `.github/workflows/release.yml`
+in each PJ to avoid the bump→clobber loop.
+<!-- kata:agents:rust:end -->
+<!-- kata:agents:rust-cli:begin -->
+### Rust CLI release flow
+
+This is a Rust CLI crate, so the release pipeline is publish-aware.
+`yukimemi/pj-rust-cli` ships a tag-driven release workflow in
+`.github/workflows/release.yml` (rendered from
+`release.yml.template` for the same don't-auto-execute reason
+ci.yml uses).
+
+```sh
+# Bump `package.version` in Cargo.toml (run `cargo build` so
+# Cargo.lock follows), then:
+git commit -am "chore: bump version to X.Y.Z"
+git tag -a vX.Y.Z -m "vX.Y.Z"
+git push origin main vX.Y.Z
+```
+
+The workflow then:
+1. Cross-compiles binaries for x86_64 Linux / Windows / macOS,
+   plus aarch64 macOS (Apple Silicon) — full triples
+   `x86_64-unknown-linux-gnu`, `x86_64-pc-windows-msvc`,
+   `x86_64-apple-darwin`, `aarch64-apple-darwin`.
+2. Uploads them as a GitHub Release with auto-generated notes.
+3. `cargo publish --locked` to crates.io using the
+   `CARGO_REGISTRY_TOKEN` repo secret.
+
+Set the `CARGO_REGISTRY_TOKEN` secret once per repo (`gh secret
+set CARGO_REGISTRY_TOKEN`) before the first tag push. If the
+crate is internal-only and shouldn't go to crates.io, either drop
+the `publish` job locally (release.yml is `when = "once"` so the
+edit survives subsequent applies) or set `package.publish = false`
+in `Cargo.toml`.
+
+The binary name is derived from the GitHub repo name at runtime
+(`${{ github.event.repository.name }}`), so the workflow is
+identical across yukimemi/* CLIs unless your `[[bin]] name` in
+`Cargo.toml` deliberately differs from the repo name — in that
+case override `BIN_NAME` in the workflow's `env:` block.
+<!-- kata:agents:rust-cli:end -->

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
-# CLAUDE.md
+# GEMINI.md
 
 This repo's agent guidance lives in [AGENTS.md](./AGENTS.md). This
-file is a thin shim so Claude Code's per-repo entry point keeps
+file is a thin shim so the Gemini CLI's per-repo entry point keeps
 working — please read AGENTS.md for the actual instructions.

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -49,32 +49,103 @@ hook_file = set "${hook_dir}/pre-push"
 mkdir ${hook_dir}
 hook_content = set "#!/bin/sh\n# Installed by: cargo make hook-install\ncargo make check"
 writefile ${hook_file} ${hook_content}
+# chmod +x is needed on Unix; on Windows the exec bit is a no-op
+# AND `chmod` may not be on PATH (it's only present when Git for
+# Windows / busybox is wired into the shell). Skip silently if
+# `chmod` isn't reachable so plain Windows shells don't fail this
+# task with `program not found`.
+chmod_path = which chmod
+if not is_empty ${chmod_path}
+    exec chmod +x ${hook_file}
+else
+    echo "chmod not on PATH; skipping exec-bit (no-op on Windows; on Unix this means the hook may not be executable)"
+end
 echo "Installed pre-push hook -> ${hook_file}"
 '''
 
 [tasks.apm-install]
-description = "Install agent skills declared in apm.yml — pinned to copilot, claude, and gemini targets"
-command = "apm"
-args = ["install", "-t", "copilot,claude,gemini"]
+description = "Install agent skills declared in apm.yml (Copilot / Claude / Gemini targets). Skipped silently when apm.yml or the apm CLI is absent."
+script_runner = "@duckscript"
+script = '''
+exists = is_path_exists "apm.yml"
+if not ${exists}
+    echo "no apm.yml; skipping apm-install"
+    exit 0
+end
+apm_path = which apm
+if is_empty ${apm_path}
+    echo "apm CLI not on PATH; skipping apm-install (install via aka.ms/apm-unix or your platform's package manager)"
+    exit 0
+end
+exec apm install -t copilot,claude,gemini
+'''
 
 [tasks.apm-install-update]
-description = "Refresh APM dependencies to upstream latest (used by on-add hook)"
-command = "apm"
-args = ["install", "--update", "-t", "copilot,claude,gemini"]
+description = "Refresh APM dependencies to upstream latest. Skipped when apm.yml/apm absent, or when apm.lock.yaml already records the current upstream renri HEAD (kicks in on every cargo make on-add after the first to keep worktree creation fast)."
+script_runner = "@duckscript"
+script = '''
+exists = is_path_exists "apm.yml"
+if not ${exists}
+    echo "no apm.yml; skipping apm-install-update"
+    exit 0
+end
+apm_path = which apm
+if is_empty ${apm_path}
+    echo "apm CLI not on PATH; skipping apm-install-update (install via aka.ms/apm-unix or your platform's package manager)"
+    exit 0
+end
+
+# Fast-path: if apm.lock.yaml already records the current
+# upstream HEAD of yukimemi/renri (the only APM dependency for
+# yukimemi/* projects), don't re-run `apm install --update` —
+# git ls-remote is ~100ms, an actual reinstall is several
+# seconds. This makes `cargo make on-add` cheap on every
+# `renri add` after the first.
+lock_exists = is_path_exists "apm.lock.yaml"
+if ${lock_exists}
+    ls_result = exec git ls-remote https://github.com/yukimemi/renri.git refs/heads/main
+    ls_ok = eq ${ls_result.code} 0
+    if ${ls_ok}
+        upstream_line = trim ${ls_result.stdout}
+        upstream_sha = substring ${upstream_line} 0 40
+        # Guard against empty / short upstream_sha. duckscript's
+        # `contains "haystack" ""` returns true (empty needle is
+        # always a substring), so without this check a successful-
+        # but-empty `git ls-remote` (deleted main ref, weird CI
+        # mirror, etc.) would incorrectly skip the install.
+        sha_len = length ${upstream_sha}
+        sha_valid = eq ${sha_len} 40
+        if ${sha_valid}
+            lock_body = readfile apm.lock.yaml
+            already_synced = contains ${lock_body} ${upstream_sha}
+            if ${already_synced}
+                echo "apm.lock.yaml already at upstream renri ${upstream_sha}; skipping apm install --update"
+                exit 0
+            end
+        end
+    end
+end
+
+exec apm install --update -t copilot,claude,gemini
+'''
+
+[tasks.setup]
+description = "One-time setup for new contributors: pre-push hook + APM install"
+dependencies = ["hook-install", "apm-install"]
 
 [tasks.vcs-fetch]
 description = "Fetch latest refs (jj when in a jj workspace, otherwise git)"
+# Best-effort: a missing `jj` / `git` binary, an unreachable remote, etc.
+# should log but not fail `cargo make on-add` and break `renri add`.
+ignore_errors = true
 script_runner = "@duckscript"
 script = '''
 # A non-colocated jj workspace has `.jj/` but no `.git/`, and `git fetch`
 # fails there with "not a git repository". Prefer `jj git fetch`, which
 # works in pure-jj and colocated repos. Fall back to `git fetch` for
 # pure-git (no `.jj/`) worktrees.
-#
-# Best-effort: don't `--fail-on-error` because a transient network
-# failure during `renri add` shouldn't break the worktree; the user
-# can always `cargo make vcs-fetch` later.
-if is_path_exists .jj
+jj_present = is_path_exists ".jj"
+if ${jj_present}
     exec jj git fetch
 else
     exec git fetch
@@ -84,7 +155,3 @@ end
 [tasks.on-add]
 description = "Wired to renri's [[hooks.post_create]] — runs in a freshly created worktree"
 dependencies = ["apm-install-update", "vcs-fetch"]
-
-[tasks.setup]
-description = "One-time setup for new contributors: pre-push hook + APM install (requires `apm` CLI on PATH — see https://github.com/microsoft/apm)"
-dependencies = ["hook-install", "apm-install"]

--- a/apm.yml
+++ b/apm.yml
@@ -1,14 +1,13 @@
-# Required-by-APM but intentionally static. Per CLAUDE.md "Version lives
-# only in Cargo.toml"; this apm.yml is consumer-side and not a publishable
-# APM package, so the version below is a placeholder that should never bump.
+# Required-by-APM but intentionally static. yukimemi/* projects
+# are not APM publishers; this apm.yml exists only to install
+# agent skills that contributors want available while working on
+# this repo — currently the `renri` worktree skill.
 name: todoke
 version: 0.0.0
 description: |
-  Dev-consumer APM config for the todoke repo. todoke itself is a Rust
-  CLI and ships no agent primitives; this apm.yml only exists to install
-  agent skills that contributors want available while working on todoke
-  — currently just the `renri` skill so AI sessions can manage
-  worktrees / jj workspaces while developing.
+  Dev-consumer APM config for the todoke repo. Pinned
+  to `#main` so `apm install --update` always pulls the latest
+  renri skill.
 author: yukimemi
 dependencies:
   apm:

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,9 @@
+# yukimemi/* Rust clippy policy. Centralised in
+# `yukimemi/pj-rust`; every Rust project picks this up via
+# `kata apply` (overwrite always). Local edits don't survive
+# `kata apply` — push the change here.
+
+# MSRV — keeps `cargo clippy` from suggesting features that are
+# stable on `stable` but not yet on the project's pinned MSRV.
+# Bumped together with `package.rust-version` in Cargo.toml.
+msrv = "1.85"

--- a/renovate.json
+++ b/renovate.json
@@ -13,16 +13,37 @@
   },
   "prHourlyLimit": 4,
   "prConcurrentLimit": 8,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.github/workflows/.+\\.template$"],
+      "matchStrings": [
+        "uses:\\s*(?<depName>[\\w./-]+)@(?<currentValue>[\\w.-]+)"
+      ],
+      "datasourceTemplate": "github-tags",
+      "description": "Pick up `uses:` action references inside .template workflow files (kata sources). Renovate's default github-actions manager only scans .yml/.yaml; .template is here so the source isn't auto-executed by GitHub Actions."
+    }
+  ],
   "packageRules": [
     {
-      "description": "Auto-merge patch-level updates once CI passes",
+      "description": "Auto-merge patch / pin / digest bumps once CI passes",
       "matchUpdateTypes": ["patch", "pin", "digest"],
       "automerge": true
     },
     {
-      "description": "Group all GitHub Actions updates into one PR",
-      "matchManagers": ["github-actions"],
+      "description": "Group all GitHub Actions updates into one PR (covers both the built-in github-actions manager and the regex customManager that scans .template files). matchDatasources scopes this to github-tags so future customManagers for non-actions deps don't accidentally land in the github-actions group.",
+      "matchManagers": ["github-actions", "regex"],
+      "matchDatasources": ["github-tags"],
       "groupName": "github-actions"
+    },
+    {
+      "description": "These workflow files are kata-managed (sourced from yukimemi/pj-rust* templates). Action bumps happen centrally there; local edits would be reverted by the next `kata apply`.",
+      "matchManagers": ["github-actions"],
+      "matchFileNames": [
+        ".github/workflows/ci.yml",
+        ".github/workflows/release.yml"
+      ],
+      "enabled": false
     }
   ]
 }

--- a/renri.toml
+++ b/renri.toml
@@ -1,4 +1,19 @@
-# renri.toml
+# renri.toml — language-agnostic worktree config for yukimemi/* projects.
+# pj-base ships the minimum hook chain that any PJ benefits from
+# (refresh installed agent skills); language-specific layers
+# (pj-rust, pj-go, pj-bun) overwrite this file with a richer hook
+# that delegates to the project's build-system on-add task.
+
+[ui]
+# Surface the GitHub PR # next to each worktree in `renri list`.
+# renri batches `gh pr list` lookups (one call per `list` run
+# regardless of worktree count) and caches the result; pass
+# `renri list --refresh` to bypass the cache when a new PR has
+# just been opened or merged.
+show_pr = true
+# renri.toml — fresh worktrees run `cargo make on-add`, which
+# refreshes apm skills *and* fetches the upstream remote so the
+# new worktree is rebase-ready without a second command.
 # Schema and examples: https://github.com/yukimemi/renri
 
 [[hooks.post_create]]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+profile = "default"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,6 @@
+# yukimemi/* Rust formatting policy. Centralised in
+# `yukimemi/pj-rust`; every Rust project picks this up via
+# `kata apply` (overwrite always). Local edits don't survive
+# `kata apply` — push the change here.
+
+edition = "2024"


### PR DESCRIPTION
## Summary

Apply [`yukimemi/pj-presets:rust-cli`](https://github.com/yukimemi/pj-presets) (= pj-base + pj-rust + pj-rust-cli) to todoke and dedupe the existing `CLAUDE.md` guidance into a new `AGENTS.md` (the agent-agnostic source of truth per the [agents.md](https://agents.md) convention). `CLAUDE.md` and the new `GEMINI.md` become thin shims pointing at `AGENTS.md`.

## Dedupe map

**Todoke-specific top of AGENTS.md** (kept verbatim from CLAUDE.md):
- What todoke is
- Source layout
- Key design decisions (auto-detect file-first / three-phase rule matching / joined-vs-passthrough exclusivity / consumes-* exclusivity / two-pass TOML pre-render / neovim backend constraints)
- TDD policy
- Useful invocations
- Version + changelog (`<type>: <summary> (vX.Y.Z)` commit-title convention)

**Sections covered by the new kata marker blocks** (now sourced from pj-base / pj-rust / pj-rust-cli, dropped from the consumer side):
- generic Testing build commands → kata `pj-rust ### Build / lint / test`
- generic Contribution workflow + PR review cycle → kata `pj-base ### Git workflow` / `### PR review cycle`

## Other writes

- `cargo-make` / `clippy.toml` / `rustfmt.toml` / `rust-toolchain.toml` / `.editorconfig` — yukimemi/* baselines from pj-rust / pj-rust-cli.
- `renovate.json` — yukimemi/* canonical config (auto-merge patch/pin/digest, lockFileMaintenance, regex customManager + matchDatasources for `.template` workflow files).
- `.github/workflows/{ci,release}.yml` — kata-managed (cli release variant: cross-compile + GitHub Release + crates.io publish).
- `.kata/applied.toml` — registry of which templates landed where.

## Follow-up after merge

Register todoke into the global kata registry so it joins the multi-PJ workflow:

\`\`\`sh
cd ~/src/github.com/yukimemi/todoke
kata register --tag rust --tag cli
kata list --all   # confirm todoke shows up
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Build/Release**
  * Simplified binary packaging in release workflow; removed duplicate alias artifacts for cleaner distributions.

* **Documentation**
  * Reorganized agent guidance into centralized documentation for easier reference.

* **Chores**
  * Standardized project configuration: added code formatting standards, Rust toolchain settings, linting policies, and dependency management rules.
  * Enhanced development environment setup with improved build tasks and version control integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->