### PR TITLE
docs(readme): add DeepWiki and Code Wiki badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
   <a href="https://crates.io/crates/todoke"><img src="https://img.shields.io/crates/v/todoke.svg" alt="crates.io"/></a>
   <a href="https://github.com/yukimemi/todoke/actions"><img src="https://github.com/yukimemi/todoke/actions/workflows/ci.yml/badge.svg" alt="CI"/></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"/></a>
+  <a href="https://deepwiki.com/yukimemi/todoke"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"/></a>
+  <a href="https://codewiki.google/github.com/yukimemi/todoke"><img src="https://img.shields.io/badge/View-Code_Wiki-4285F4?logo=google" alt="View Code Wiki"/></a>
 </p>
 
 `todoke` takes one or more file paths and decides what to do with each of


### PR DESCRIPTION
## Summary
- Add **Ask DeepWiki** and **View Code Wiki** badges to the README's badge block.
- Both link to the corresponding AI-generated wiki pages so readers can chat-explore the codebase without cloning.

## Test plan
- [ ] GitHub renders both badges in the README preview
- [ ] DeepWiki link resolves to https://deepwiki.com/yukimemi/todoke
- [ ] Code Wiki link resolves to https://codewiki.google/github.com/yukimemi/todoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)