### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.github/workflows/apm-bump.yml
+++ b/.github/workflows/apm-bump.yml
@@ -71,6 +71,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
         with:
           token: ${{ secrets.KATA_APPLY_TOKEN }}
+          persist-credentials: false
 
       - name: Install apm
         # aka.ms/apm-unix is the Unix one-liner installer published

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   # Cargo binary name derived from the GitHub repo so this template
-  # works unchanged for any yukimemi/* CLI without per-PJ patching.
+  # works unchanged for any CLI using these templates without per-PJ patching.
   # If your `[[bin]] name` in Cargo.toml differs from the repo name,
   # override this on the spot.
   BIN_NAME: ${{ github.event.repository.name }}
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
           - target: x86_64-pc-windows-msvc
             os: windows-latest
@@ -38,7 +38,21 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
+      - name: install musl toolchain
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: sudo apt-get install -y musl-tools
       - run: cargo build --release --target ${{ matrix.target }}
+      # Run the `smoke` example on the same runner that produced the
+      # binary. The example's default body is a no-op (see
+      # `examples/smoke.rs` in the consumer crate); each crate is
+      # expected to override it with a real-world startup check
+      # (HTTPS handshake, I/O probe, etc.) so this step blocks a
+      # release before bad binaries reach users — `cargo test` runs
+      # only library code and missed shoka v0.10.0's rustls panic.
+      - name: smoke
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: cargo run --release --target ${{ matrix.target }} --example smoke
       - name: package (unix)
         if: runner.os != 'Windows'
         run: |

--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,20 +1,20 @@
 preset = "github.com/yukimemi/pj-presets:rust-cli"
-applied_at = "2026-05-30T04:37:18.142638204Z"
+applied_at = "2026-05-31T04:49:12.061761379Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"
-rev = "3e3c7ee971897ae6cc71e78d597c838412974f19"
+rev = "98a48d8489551fffcf08e71da8b85d00d5e74dfd"
 version = "0.12.1"
 
 [[templates]]
 source = "github.com/yukimemi/pj-rust"
-rev = "f78e190bac618fc3870b3c4a6e4187eb01c3cc42"
-version = "0.7.0"
+rev = "6ac24c5f06b08962ad3f55e5142606824846ec7a"
+version = "0.8.0"
 
 [[templates]]
 source = "github.com/yukimemi/pj-rust-cli"
-rev = "3cc89e5f11c2a83dc4cd3c10a56c49306b444975"
-version = "0.3.0"
+rev = "d6549f7d1333c1ce9e4ef9d061d5cd333433da4c"
+version = "0.4.1"
 
 [files.".agents/skills/renri/SKILL.md"]
 once_applied = true
@@ -33,7 +33,7 @@ content_hash = "486c974de88903113ed99b4e643432b7050e88f1031276f5263e8da7b43fe11e
 content_hash = "6d380d1ecc2f882c2011429d548a6f3c774b74f0c757d884453e4667172acc2a"
 
 [files.".github/workflows/apm-bump.yml"]
-content_hash = "79b12afa028841f8bce3c0caffd60dfe491642dba685142e33ed22a8cfcb9f9d"
+content_hash = "f6f32f9e34c386faf21abfb786ffc1a81d76913be63d31b063e44517dcfb148d"
 
 [files.".github/workflows/auto-tag.yml"]
 content_hash = "0796dfb281c7447610035360622ddada137a8e2d89efa574aea89374676d768b"
@@ -45,7 +45,7 @@ content_hash = "594c14cf24dd2aa17d8c50d0db6d56321cb729ad4fc660888d7e6fbe36ca9211
 content_hash = "bc0e3def04b634949297d60322999a27f53bffc71b6cb662ae58ac8087e78bed"
 
 [files.".github/workflows/release.yml"]
-content_hash = "fd5c3f524d212d7d237b9f410d0d2a0378e2a434ddac1dadef38da1bcc46fb2b"
+content_hash = "9bb2700bfdcf9036cd7f3c79a58f6e5b22fe0595706b27c6159f6c1b0c0da383"
 once_applied = true
 
 [files.".gitignore"]
@@ -88,6 +88,7 @@ once_applied = true
 content_hash = "2ada1cf4347db9e98fadd67ca72cd9e29042c5bf6ab719d666b5d71f97663e81"
 
 [files."renovate.json"]
+content_hash = "ea464978679041c69a3e18085f9a2ce846b9762ff02ab2801ed22cfbbf1487ae"
 once_applied = true
 
 [files."renri.toml"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,11 +310,11 @@ either way; using a PR also gives CI a chance to gate the
 release. Enable automerge so CI green = release start:
 
 ```sh
-git switch -c chore/bump-X.Y.Z
+git switch -c chore/release-vX.Y.Z
 # Edit `package.version` in Cargo.toml, then:
 cargo build                     # let Cargo.lock follow
-git commit -am "chore: bump version to X.Y.Z"
-git push -u origin chore/bump-X.Y.Z
+git commit -am "chore: release vX.Y.Z"
+git push -u origin chore/release-vX.Y.Z
 gh pr create --fill
 gh pr merge --auto --squash --delete-branch
 ```

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>yukimemi/pj-base"]
+  "extends": [
+    "github>yukimemi/pj-rust"
+  ]
 }


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails.

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to enhance build security and add post-build smoke testing.
  * Updated dependency management configuration to extend the Rust-based preset.
  * Updated application metadata and template references.

* **Documentation**
  * Updated release procedure documentation with revised branch naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->