### PR TITLE
chore(apm): refresh apm.lock.yaml

### DIFF
--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,14 +1,13 @@
 lockfile_version: '1'
-generated_at: '2026-05-03T04:44:44.522774+00:00'
-apm_version: 0.11.0
+generated_at: '2026-06-01T05:44:57.652877+00:00'
+apm_version: 0.16.0
 dependencies:
 - repo_url: yukimemi/renri
   host: github.com
-  resolved_commit: 6b034f40323225855d2ffce0b15a77807e441723
+  resolved_commit: 1bc5976892f4200280b6227ca71deead6c40a574
   resolved_ref: main
   package_type: apm_package
   deployed_files:
+  - .agents/skills/renri
   - .claude/skills/renri
-  - .gemini/skills/renri
-  - .github/skills/renri
-  content_hash: sha256:8362ac856f78eefaf5cede49891bee311a56905d6f17b0b3e69f8aac46c2b72b
+  content_hash: sha256:8ac9660ed09c5fcc48e4855896466885f3c03b03c55763fda2df250819e2b065


### PR DESCRIPTION
Automated `apm install --update` (weekly schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails.

<!-- pj-base ships this workflow; see yukimemi/pj-base -->