### PR TITLE
chore(release): v2.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2535,7 +2535,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "todoke"
-version = "2.2.2"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "todoke"
-version = "2.2.2"
+version = "2.3.0"
 edition = "2024"
 rust-version = "1.85"
 description = "A rule-driven file and URL dispatcher: hands incoming paths (or URLs) to the right handler based on TOML-defined rules."


### PR DESCRIPTION
Release v2.3.0: version bump only (kaishin 0.5.0 background auto-update feature, already merged). Triggers auto-tag -> release.yml. Version-bump-only PR — skips the bot-review gate per AGENTS.md.