### PR TITLE
chore(apm): refresh apm.lock.yaml

### DIFF
--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,13 +1,13 @@
 lockfile_version: '1'
-generated_at: '2026-06-01T05:44:57.652877+00:00'
-apm_version: 0.16.0
+generated_at: '2026-06-08T05:41:59.001059+00:00'
+apm_version: 0.18.0
 dependencies:
 - repo_url: yukimemi/renri
   host: github.com
-  resolved_commit: 1bc5976892f4200280b6227ca71deead6c40a574
+  resolved_commit: d9f7c890d4afdd8762ed03bcc5e96a93d15a5bdc
   resolved_ref: main
   package_type: apm_package
   deployed_files:
   - .agents/skills/renri
   - .claude/skills/renri
-  content_hash: sha256:8ac9660ed09c5fcc48e4855896466885f3c03b03c55763fda2df250819e2b065
+  content_hash: sha256:c49ccb7e02f09139adcde2be61f4bdd86871de150c7d37d2ca19608a97fbd9b2


### PR DESCRIPTION
Automated `apm install --update` (weekly schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails.

<!-- pj-base ships this workflow; see yukimemi/pj-base -->